### PR TITLE
fix(ci): align frontend to pnpm

### DIFF
--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
+        with:
+          package_json_file: src/frontend/package.json
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
- Add pnpm/action-setup@v4 to cd-frontend workflow
- Switch cache and commands from npm to pnpm
- Add packageManager field to frontend package.json
- Replace package-lock.json with pnpm-lock.yaml
- Update infra/README.md paths for src/ structure
- Standardize docs on pnpm (remove npm/yarn/bun alternatives)

## Summary

Brief description of what this PR does.

## Changes

- Added X
- Modified Y
- Removed Z

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests pass
- [ ] Manual testing completed

## Checklist

- [ ] Code follows project [coding standards](../CODING_STANDARD.md)
- [ ] Tests pass locally (`uv run poe check`)
- [ ] Documentation updated if needed
- [ ] Commit messages follow [Conventional Commits](../CONTRIBUTING.md#commit-message-format)
- [ ] PR title follows Conventional Commits format

## Related Issues

Closes #

## Additional Notes

<!-- Any additional context, screenshots, or information -->
