### PR TITLE
feat(frontend): add DataTable with column formatting

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,7 +5,6 @@
         "charliermarsh.ruff",
         "tamasfe.even-better-toml",
         "redhat.vscode-yaml",
-        "github.copilot",
         "github.copilot-chat",
         "davidanson.vscode-markdownlint",
         "ms-azuretools.vscode-azureterraform",

--- a/src/frontend/components/tool-ui/data-table/_adapter.tsx
+++ b/src/frontend/components/tool-ui/data-table/_adapter.tsx
@@ -1,0 +1,40 @@
+/**
+ * Adapter: UI and utility re-exports for copy-standalone portability.
+ *
+ * When copying this component to another project, update these imports
+ * to match your project's paths:
+ *
+ *   cn           → Your Tailwind merge utility (e.g., "@/lib/utils", "~/lib/cn")
+ *   Button       → shadcn/ui Button
+ *   DropdownMenu → shadcn/ui DropdownMenu
+ *   Accordion    → shadcn/ui Accordion
+ *   Tooltip      → shadcn/ui Tooltip
+ *   Badge        → shadcn/ui Badge
+ *   Table        → shadcn/ui Table
+ */
+
+export { cn } from "@/lib/utils";
+export {
+    Accordion,
+    AccordionContent,
+    AccordionItem,
+    AccordionTrigger
+} from "../../ui/accordion";
+export { Badge } from "../../ui/badge";
+export { Button } from "../../ui/button";
+export {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger
+} from "../../ui/dropdown-menu";
+export {
+    Table, TableBody, TableCell, TableHead, TableHeader, TableRow
+} from "../../ui/table";
+export {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger
+} from "../../ui/tooltip";
+

--- a/src/frontend/components/tool-ui/data-table/data-table.tsx
+++ b/src/frontend/components/tool-ui/data-table/data-table.tsx
@@ -1,0 +1,933 @@
+"use client";
+
+import * as React from "react";
+import { ActionButtons, normalizeActionsConfig } from "../shared";
+import {
+    Accordion,
+    AccordionContent,
+    AccordionItem,
+    AccordionTrigger,
+    Button,
+    cn,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from "./_adapter";
+import { DataTableErrorBoundary } from "./error-boundary";
+import type { FormatConfig } from "./formatters";
+import { renderFormattedValue } from "./formatters";
+import type {
+    Column,
+    ColumnKey,
+    DataTableContextValue,
+    DataTableProps,
+    DataTableRowData,
+    RowData,
+} from "./types";
+import { getRowIdentifier, sortData } from "./utilities";
+
+export const DEFAULT_LOCALE = "en-US" as const;
+
+function isNumericFormat(format?: FormatConfig): boolean {
+    const kind = format?.kind;
+    return (
+        kind === "number" ||
+        kind === "currency" ||
+        kind === "percent" ||
+        kind === "delta"
+    );
+}
+
+function getAlignmentClass(
+    align?: "left" | "right" | "center",
+): string | undefined {
+    if (align === "right") return "text-right";
+    if (align === "center") return "text-center";
+    return undefined;
+}
+
+const DataTableContext = React.createContext<
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    DataTableContextValue<any> | undefined
+>(undefined);
+
+export function useDataTable<T extends object = RowData>() {
+    const context = React.useContext(DataTableContext) as
+        | DataTableContextValue<T>
+        | undefined;
+    if (!context) {
+        throw new Error("useDataTable must be used within <DataTable.Provider />");
+    }
+    return context;
+}
+
+type DataTableLayout = "auto" | "table" | "cards";
+
+type DataTableBaseProps<T extends object = RowData> = DataTableProps<T> & {
+    layout: DataTableLayout;
+};
+
+type DataTableProviderProps<T extends object = RowData> = Pick<
+    DataTableProps<T>,
+    | "columns"
+    | "data"
+    | "rowIdKey"
+    | "defaultSort"
+    | "sort"
+    | "onSortChange"
+    | "id"
+    | "locale"
+> & {
+    children: React.ReactNode;
+};
+
+function DataTableProvider<T extends object = RowData>({
+    columns,
+    data: rawData,
+    rowIdKey,
+    defaultSort,
+    sort: controlledSort,
+    id,
+    onSortChange,
+    locale,
+    children,
+}: DataTableProviderProps<T>) {
+    // Default locale avoids SSR/client formatting mismatches.
+    const resolvedLocale = locale ?? DEFAULT_LOCALE;
+
+    const [internalSortBy, setInternalSortBy] = React.useState<
+        ColumnKey<T> | undefined
+    >(defaultSort?.by);
+    const [internalSortDirection, setInternalSortDirection] = React.useState<
+        "asc" | "desc" | undefined
+    >(defaultSort?.direction);
+
+    const sortBy = controlledSort?.by ?? internalSortBy;
+    const sortDirection = controlledSort?.direction ?? internalSortDirection;
+
+    const data = React.useMemo(() => {
+        if (!sortBy || !sortDirection) return rawData;
+        return sortData(rawData, sortBy, sortDirection, resolvedLocale);
+    }, [rawData, sortBy, sortDirection, resolvedLocale]);
+
+    const handleSort = React.useCallback(
+        (key: ColumnKey<T>) => {
+            let newDirection: "asc" | "desc" | undefined;
+
+            if (sortBy === key) {
+                if (sortDirection === "asc") {
+                    newDirection = "desc";
+                } else if (sortDirection === "desc") {
+                    newDirection = undefined;
+                } else {
+                    newDirection = "asc";
+                }
+            } else {
+                newDirection = "asc";
+            }
+
+            const next = {
+                by: newDirection ? key : undefined,
+                direction: newDirection,
+            } as const;
+
+            if (controlledSort) {
+                onSortChange?.(next);
+            } else {
+                setInternalSortBy(next.by);
+                setInternalSortDirection(next.direction);
+            }
+        },
+        [sortBy, sortDirection, controlledSort, onSortChange],
+    );
+
+    const contextValue: DataTableContextValue<T> = {
+        columns,
+        data,
+        rowIdKey,
+        sortBy,
+        sortDirection,
+        toggleSort: handleSort,
+        id,
+        locale: resolvedLocale,
+    };
+
+    return (
+        <DataTableContext.Provider value={contextValue}>
+            {children}
+        </DataTableContext.Provider>
+    );
+}
+
+interface DataTableLayoutProps {
+    layout: DataTableLayout;
+    emptyMessage: string;
+    maxHeight?: string;
+    className?: string;
+    responseActions?: DataTableProps["responseActions"];
+    onResponseAction?: DataTableProps["onResponseAction"];
+    onBeforeResponseAction?: DataTableProps["onBeforeResponseAction"];
+}
+
+function DataTableLayout({
+    layout,
+    emptyMessage,
+    maxHeight,
+    className,
+    responseActions,
+    onResponseAction,
+    onBeforeResponseAction,
+}: DataTableLayoutProps) {
+    const { columns, data, rowIdKey, sortBy, sortDirection, id } = useDataTable();
+
+    const sortAnnouncement = React.useMemo(() => {
+        const col = columns.find((c) => c.key === sortBy);
+        const label = col?.label ?? sortBy;
+        return sortBy && sortDirection
+            ? `Sorted by ${label}, ${sortDirection === "asc" ? "ascending" : "descending"}`
+            : "";
+    }, [columns, sortBy, sortDirection]);
+
+    const normalizedFooterActions = React.useMemo(
+        () => normalizeActionsConfig(responseActions),
+        [responseActions],
+    );
+
+    return (
+        <div
+            className={cn("@container w-full min-w-80", className)}
+            data-tool-ui-id={id}
+            data-slot="data-table"
+            data-layout={layout}
+        >
+            <div
+                className={cn(
+                    layout === "table"
+                        ? "block"
+                        : layout === "cards"
+                            ? "hidden"
+                            : "hidden @md:block",
+                )}
+            >
+                <div className="relative">
+                    <div
+                        className={cn(
+                            "bg-card relative w-full overflow-clip overflow-y-auto rounded-lg border",
+                            "touch-pan-x",
+                            maxHeight && "max-h-[--max-height]",
+                        )}
+                        style={
+                            maxHeight
+                                ? ({ "--max-height": maxHeight } as React.CSSProperties)
+                                : undefined
+                        }
+                    >
+                        <DataTableErrorBoundary>
+                            <Table className="table-fixed">
+                                {columns.length > 0 && (
+                                    <colgroup>
+                                        {columns.map((col) => (
+                                            <col
+                                                key={String(col.key)}
+                                                style={col.width ? { width: col.width } : undefined}
+                                            />
+                                        ))}
+                                    </colgroup>
+                                )}
+                                {data.length === 0 ? (
+                                    <DataTableEmpty message={emptyMessage} />
+                                ) : (
+                                    <DataTableContent />
+                                )}
+                            </Table>
+                        </DataTableErrorBoundary>
+                    </div>
+                </div>
+            </div>
+
+            <div
+                className={cn(
+                    layout === "cards" ? "" : layout === "table" ? "hidden" : "@md:hidden",
+                )}
+                role="list"
+                aria-label="Data table (mobile card view)"
+                aria-describedby="mobile-table-description"
+            >
+                <div id="mobile-table-description" className="sr-only">
+                    Table data shown as expandable cards. Each card represents one row.
+                    {columns.length > 0 &&
+                        ` Columns: ${columns.map((c) => c.label).join(", ")}.`}
+                </div>
+
+                <DataTableErrorBoundary>
+                    {data.length === 0 ? (
+                        <div className="text-muted-foreground py-8 text-center">
+                            {emptyMessage}
+                        </div>
+                    ) : (
+                        <div className="bg-card flex flex-col overflow-hidden rounded-2xl border shadow-xs">
+                            {data.map((row, i) => {
+                                const keyVal = rowIdKey ? row[rowIdKey] : undefined;
+                                const rowKey = keyVal != null ? String(keyVal) : String(i);
+                                return (
+                                    <DataTableAccordionCard
+                                        key={rowKey}
+                                        row={row as unknown as DataTableRowData}
+                                        index={i}
+                                        isFirst={i === 0}
+                                    />
+                                );
+                            })}
+                        </div>
+                    )}
+                </DataTableErrorBoundary>
+            </div>
+
+            {sortAnnouncement && (
+                <div className="sr-only" aria-live="polite">
+                    {sortAnnouncement}
+                </div>
+            )}
+
+            {normalizedFooterActions ? (
+                <div className="@container/actions mt-4">
+                    <ActionButtons
+                        actions={normalizedFooterActions.items}
+                        align={normalizedFooterActions.align}
+                        confirmTimeout={normalizedFooterActions.confirmTimeout}
+                        onAction={(actionId) => onResponseAction?.(actionId)}
+                        onBeforeAction={onBeforeResponseAction}
+                    />
+                </div>
+            ) : null}
+        </div>
+    );
+}
+
+function DataTableBase<T extends object = RowData>(props: DataTableBaseProps<T>) {
+    const {
+        columns,
+        data,
+        rowIdKey,
+        defaultSort,
+        sort,
+        onSortChange,
+        id,
+        locale,
+        layout,
+        emptyMessage = "No data available",
+        maxHeight,
+        className,
+        responseActions,
+        onResponseAction,
+        onBeforeResponseAction,
+    } = props;
+
+    return (
+        <DataTableProvider
+            columns={columns}
+            data={data}
+            rowIdKey={rowIdKey}
+            defaultSort={defaultSort}
+            sort={sort}
+            onSortChange={onSortChange}
+            id={id}
+            locale={locale}
+        >
+            <DataTableLayout
+                layout={layout}
+                emptyMessage={emptyMessage}
+                maxHeight={maxHeight}
+                className={className}
+                responseActions={responseActions}
+                onResponseAction={onResponseAction}
+                onBeforeResponseAction={onBeforeResponseAction}
+            />
+        </DataTableProvider>
+    );
+}
+
+function DataTableRoot<T extends object = RowData>(props: DataTableProps<T>) {
+    return <DataTableBase {...props} layout="auto" />;
+}
+
+function DataTableTable<T extends object = RowData>(props: DataTableProps<T>) {
+    return <DataTableBase {...props} layout="table" />;
+}
+
+function DataTableCards<T extends object = RowData>(props: DataTableProps<T>) {
+    return <DataTableBase {...props} layout="cards" />;
+}
+
+type DataTableComponent = {
+    <T extends object = RowData>(props: DataTableProps<T>): React.ReactElement;
+    Table: typeof DataTableTable;
+    Cards: typeof DataTableCards;
+    Provider: typeof DataTableProvider;
+};
+
+export const DataTable = Object.assign(DataTableRoot, {
+    Table: DataTableTable,
+    Cards: DataTableCards,
+    Provider: DataTableProvider,
+}) as DataTableComponent;
+
+function DataTableContent() {
+    return (
+        <>
+            <DataTableHeader />
+            <DataTableBody />
+        </>
+    );
+}
+
+function DataTableEmpty({ message }: { message: string }) {
+    const { columns } = useDataTable();
+
+    return (
+        <TableBody>
+            <TableRow className="bg-card h-24 text-center">
+                <TableCell colSpan={columns.length} role="status" aria-live="polite">
+                    {message}
+                </TableCell>
+            </TableRow>
+        </TableBody>
+    );
+}
+
+function SortIcon({ state }: { state?: "asc" | "desc" }) {
+    let char = "⇅";
+    let className = "opacity-20";
+
+    if (state === "asc") {
+        char = "↑";
+        className = "";
+    }
+
+    if (state === "desc") {
+        char = "↓";
+        className = "";
+    }
+
+    return (
+        <span aria-hidden className={cn("min-w-4 shrink-0 text-center", className)}>
+            {char}
+        </span>
+    );
+}
+
+function DataTableHeader() {
+    const { columns } = useDataTable();
+
+    return (
+        <TooltipProvider delayDuration={300}>
+            <TableHeader>
+                <TableRow className="hover:bg-transparent">
+                    {columns.map((column, columnIndex) => (
+                        <DataTableHead
+                            key={column.key}
+                            column={column}
+                            columnIndex={columnIndex}
+                            totalColumns={columns.length}
+                        />
+                    ))}
+                </TableRow>
+            </TableHeader>
+        </TooltipProvider>
+    );
+}
+
+interface DataTableHeadProps {
+    column: Column;
+    columnIndex?: number;
+    totalColumns?: number;
+}
+
+function DataTableHead({
+    column,
+    columnIndex = 0,
+    totalColumns = 1,
+}: DataTableHeadProps) {
+    const { sortBy, sortDirection, toggleSort } = useDataTable();
+    const isFirstColumn = columnIndex === 0;
+    const isLastColumn = columnIndex === totalColumns - 1;
+
+    const isSortable = column.sortable !== false;
+
+    const isSorted = sortBy === column.key;
+    const direction = isSorted ? sortDirection : undefined;
+    const isDisabled = !isSortable;
+
+    const handleClick = () => {
+        if (!isDisabled && toggleSort) {
+            toggleSort(column.key);
+        }
+    };
+
+    const displayText = column.abbr || column.label;
+    const shouldShowTooltip = column.abbr || displayText.length > 15;
+    const isNumericKind = isNumericFormat(column.format);
+    const align =
+        column.align ??
+        (columnIndex === 0 ? "left" : isNumericKind ? "right" : "left");
+    const alignClass = getAlignmentClass(align);
+    const buttonAlignClass = cn(
+        "min-w-0 gap-1 font-normal",
+        align === "right" && "text-right",
+        align === "center" && "text-center",
+        align === "left" && "text-left",
+    );
+    const labelAlignClass =
+        align === "right"
+            ? "text-right"
+            : align === "center"
+                ? "text-center"
+                : "text-left";
+
+    return (
+        <TableHead
+            scope="col"
+            className={cn(
+                alignClass,
+                isFirstColumn && "pl-1",
+                isLastColumn && "pr-1",
+            )}
+            style={column.width ? { width: column.width } : undefined}
+            aria-sort={
+                isSorted
+                    ? direction === "asc"
+                        ? "ascending"
+                        : "descending"
+                    : undefined
+            }
+        >
+            <Button
+                type="button"
+                size="sm"
+                onClick={handleClick}
+                onKeyDown={(e) => {
+                    if (isDisabled) return;
+                    if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        handleClick();
+                    }
+                }}
+                disabled={isDisabled}
+                variant="ghost"
+                className={cn(
+                    buttonAlignClass,
+                    "w-fit min-w-10",
+                    isFirstColumn && "pl-4",
+                    isLastColumn && "pr-4",
+                )}
+                aria-label={
+                    `Sort by ${column.label}` +
+                    (isSorted && direction
+                        ? ` (${direction === "asc" ? "ascending" : "descending"})`
+                        : "")
+                }
+                aria-disabled={isDisabled || undefined}
+            >
+                {shouldShowTooltip ? (
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <span className={cn("truncate", labelAlignClass)}>
+                                {column.abbr ? (
+                                    <abbr
+                                        title={column.label}
+                                        className={cn(
+                                            "cursor-help border-b border-dotted border-current no-underline",
+                                            labelAlignClass,
+                                        )}
+                                    >
+                                        {column.abbr}
+                                    </abbr>
+                                ) : (
+                                    <span className={labelAlignClass}>{column.label}</span>
+                                )}
+                            </span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            <p>{column.label}</p>
+                        </TooltipContent>
+                    </Tooltip>
+                ) : (
+                    <span className={cn("truncate", labelAlignClass)}>
+                        {column.label}
+                    </span>
+                )}
+                {isSortable && <SortIcon state={direction} />}
+            </Button>
+        </TableHead>
+    );
+}
+
+function DataTableBody() {
+    const { data, rowIdKey } = useDataTable<DataTableRowData>();
+    const hasWarnedRowKeyRef = React.useRef(false);
+
+    React.useEffect(() => {
+        if (hasWarnedRowKeyRef.current) return;
+        if (process.env.NODE_ENV !== "production" && !rowIdKey && data.length > 0) {
+            hasWarnedRowKeyRef.current = true;
+            console.warn(
+                "[DataTable] Missing `rowIdKey` prop. Using array index as React key can cause reconciliation issues when data reorders (focus traps, animation glitches, incorrect state preservation). " +
+                "Strongly recommended: Pass a `rowIdKey` prop that points to a unique identifier in your row data (e.g., 'id', 'uuid', 'symbol').\n" +
+                'Example: <DataTable rowIdKey="id" columns={...} data={...} />',
+            );
+        }
+    }, [rowIdKey, data.length]);
+
+    return (
+        <TableBody>
+            {data.map((row, index) => {
+                const keyVal = rowIdKey ? row[rowIdKey] : undefined;
+                const rowKey = keyVal != null ? String(keyVal) : String(index);
+                return <DataTableRow key={rowKey} row={row} />;
+            })}
+        </TableBody>
+    );
+}
+
+interface DataTableRowProps {
+    row: DataTableRowData;
+    className?: string;
+}
+
+function DataTableRow({ row, className }: DataTableRowProps) {
+    const { columns } = useDataTable();
+
+    return (
+        <TableRow className={className}>
+            {columns.map((column, columnIndex) => (
+                <DataTableCell
+                    key={column.key}
+                    value={row[column.key]}
+                    column={column}
+                    row={row}
+                    columnIndex={columnIndex}
+                />
+            ))}
+        </TableRow>
+    );
+}
+
+interface DataTableCellProps {
+    value:
+    | string
+    | number
+    | boolean
+    | null
+    | (string | number | boolean | null)[];
+    column: Column;
+    row: DataTableRowData;
+    className?: string;
+    columnIndex?: number;
+}
+
+function DataTableCell({
+    value,
+    column,
+    row,
+    className,
+    columnIndex = 0,
+}: DataTableCellProps) {
+    const { locale } = useDataTable();
+    const isNumericKind = isNumericFormat(column.format);
+    const isNumericValue = typeof value === "number";
+    const displayValue = renderFormattedValue({ value, column, row, locale });
+
+    const align =
+        column.align ??
+        (columnIndex === 0
+            ? "left"
+            : isNumericKind || isNumericValue
+                ? "right"
+                : "left");
+    const alignClass = getAlignmentClass(align);
+
+    return (
+        <TableCell className={cn("px-5 py-3", alignClass, className)}>
+            {displayValue}
+        </TableCell>
+    );
+}
+
+function categorizeColumns(columns: Column[]) {
+    const primary: Column[] = [];
+    const secondary: Column[] = [];
+
+    let visibleColumnCount = 0;
+    columns.forEach((col) => {
+        if (col.hideOnMobile) return;
+
+        if (col.priority === "primary") {
+            primary.push(col);
+        } else if (col.priority === "secondary") {
+            secondary.push(col);
+        } else if (col.priority === "tertiary") {
+            return;
+        } else {
+            if (visibleColumnCount < 2) {
+                primary.push(col);
+            } else {
+                secondary.push(col);
+            }
+            visibleColumnCount++;
+        }
+    });
+
+    return { primary, secondary };
+}
+
+interface DataTableAccordionCardProps {
+    row: DataTableRowData;
+    index: number;
+    isFirst?: boolean;
+}
+
+function DataTableAccordionCard({
+    row,
+    index,
+    isFirst = false,
+}: DataTableAccordionCardProps) {
+    const { columns, locale, rowIdKey } = useDataTable();
+
+    const { primary, secondary } = React.useMemo(
+        () => categorizeColumns(columns),
+        [columns],
+    );
+
+    if (secondary.length === 0) {
+        return (
+            <SimpleCard row={row} columns={primary} index={index} isFirst={isFirst} />
+        );
+    }
+
+    const primaryColumn = primary[0];
+    const remainingPrimaryColumns = primary.slice(1);
+
+    const stableRowId =
+        getRowIdentifier(row, rowIdKey ? String(rowIdKey) : undefined) ||
+        `${index}-${primaryColumn?.key ?? "row"}`;
+
+    const headingId = `row-${stableRowId}-heading`;
+    const detailsId = `row-${stableRowId}-details`;
+    const remainingPrimaryDataIds = remainingPrimaryColumns.map(
+        (col) => `row-${stableRowId}-${String(col.key)}`,
+    );
+
+    const primaryValue = primaryColumn
+        ? String(row[primaryColumn.key] ?? "")
+        : "";
+    const rowLabel = `Row ${index + 1}: ${primaryValue}`;
+    const accordionItemId = `row-${stableRowId}`;
+
+    return (
+        <Accordion
+            type="single"
+            collapsible
+            className={cn(!isFirst && "border-t")}
+            role="listitem"
+            aria-label={rowLabel}
+        >
+            <AccordionItem value={accordionItemId} className="group border-0">
+                <AccordionTrigger
+                    className="group-data-[state=closed]:hover:bg-accent/50 active:bg-accent/50 group-data-[state=open]:bg-muted w-full rounded-none px-4 py-3 hover:no-underline"
+                    aria-controls={detailsId}
+                    aria-label={`${rowLabel}. ${secondary.length > 0 ? "Expand for details" : ""}`}
+                >
+                    <div className="flex min-w-0 flex-1 flex-col gap-2">
+                        {primaryColumn && (
+                            <div
+                                id={headingId}
+                                role="heading"
+                                aria-level={3}
+                                className="truncate"
+                                aria-label={`${primaryColumn.label}: ${row[primaryColumn.key]}`}
+                            >
+                                {renderFormattedValue({
+                                    value: row[primaryColumn.key],
+                                    column: primaryColumn,
+                                    row,
+                                    locale,
+                                })}
+                            </div>
+                        )}
+
+                        {remainingPrimaryColumns.length > 0 && (
+                            <div
+                                className="text-muted-foreground flex w-full flex-wrap gap-x-4 gap-y-0.5"
+                                role="group"
+                                aria-label="Summary information"
+                            >
+                                {remainingPrimaryColumns.map((col, idx) => (
+                                    <span
+                                        key={col.key}
+                                        id={remainingPrimaryDataIds[idx]}
+                                        className="flex min-w-0 gap-1 font-normal"
+                                        role="cell"
+                                        aria-label={`${col.label}: ${row[col.key]}`}
+                                    >
+                                        <span className="sr-only">{col.label}:</span>
+                                        <span aria-hidden="true">{col.label}:</span>
+                                        <span className="truncate">
+                                            {renderFormattedValue({
+                                                value: row[col.key],
+                                                column: col,
+                                                row,
+                                                locale,
+                                            })}
+                                        </span>
+                                    </span>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                </AccordionTrigger>
+
+                <AccordionContent
+                    className={"flex flex-col gap-4 px-4 pb-4"}
+                    id={detailsId}
+                    role="region"
+                    aria-labelledby={headingId}
+                >
+                    {secondary.length > 0 && (
+                        <dl
+                            className={cn(
+                                "flex flex-col gap-2 pt-4",
+                                "motion-safe:group-data-[state=open]:animate-in motion-safe:group-data-[state=open]:fade-in-0",
+                                "motion-safe:group-data-[state=open]:slide-in-from-top-1",
+                                "motion-safe:group-data-[state=closed]:animate-out motion-safe:group-data-[state=closed]:fade-out-0",
+                                "motion-safe:group-data-[state=closed]:slide-out-to-top-1",
+                                "duration-150",
+                            )}
+                            role="list"
+                            aria-label="Additional data"
+                        >
+                            {secondary.map((col) => (
+                                <div
+                                    key={col.key}
+                                    className="flex items-start justify-between gap-4"
+                                    role="listitem"
+                                >
+                                    <dt
+                                        className="text-muted-foreground shrink-0"
+                                        id={`row-${stableRowId}-${String(col.key)}-label`}
+                                    >
+                                        {col.label}
+                                    </dt>
+                                    <dd
+                                        className={cn(
+                                            "text-foreground min-w-0 text-pretty wrap-break-word",
+                                            col.align === "right" && "text-right",
+                                            col.align === "center" && "text-center",
+                                        )}
+                                        role="cell"
+                                        aria-labelledby={`row-${stableRowId}-${String(col.key)}-label`}
+                                    >
+                                        {renderFormattedValue({
+                                            value: row[col.key],
+                                            column: col,
+                                            row,
+                                            locale,
+                                        })}
+                                    </dd>
+                                </div>
+                            ))}
+                        </dl>
+                    )}
+                </AccordionContent>
+            </AccordionItem>
+        </Accordion>
+    );
+}
+
+/**
+ * Simple card with no accordion, for when there are only primary columns
+ */
+function SimpleCard({
+    row,
+    columns,
+    index,
+    isFirst = false,
+}: {
+    row: DataTableRowData;
+    columns: Column[];
+    index: number;
+    isFirst?: boolean;
+}) {
+    const { locale, rowIdKey } = useDataTable();
+    const primaryColumn = columns[0];
+    const otherColumns = columns.slice(1);
+
+    const stableRowId =
+        getRowIdentifier(row, rowIdKey ? String(rowIdKey) : undefined) ||
+        `${index}-${primaryColumn?.key ?? "row"}`;
+
+    const primaryValue = primaryColumn
+        ? String(row[primaryColumn.key] ?? "")
+        : "";
+    const rowLabel = `Row ${index + 1}: ${primaryValue}`;
+
+    return (
+        <div
+            className={cn("flex flex-col gap-2 p-4", !isFirst && "border-t")}
+            role="listitem"
+            aria-label={rowLabel}
+        >
+            {primaryColumn && (
+                <div
+                    role="heading"
+                    aria-level={3}
+                    aria-label={`${primaryColumn.label}: ${row[primaryColumn.key]}`}
+                >
+                    {renderFormattedValue({
+                        value: row[primaryColumn.key],
+                        column: primaryColumn,
+                        row,
+                        locale,
+                    })}
+                </div>
+            )}
+
+            {otherColumns.map((col) => (
+                <div
+                    key={col.key}
+                    className="flex items-start justify-between gap-4"
+                    role="group"
+                >
+                    <span
+                        className="text-muted-foreground"
+                        id={`row-${stableRowId}-${String(col.key)}-label`}
+                    >
+                        {col.label}:
+                    </span>
+                    <span
+                        className={cn(
+                            "min-w-0 wrap-break-word",
+                            col.align === "right" && "text-right",
+                            col.align === "center" && "text-center",
+                        )}
+                        role="cell"
+                        aria-labelledby={`row-${stableRowId}-${String(col.key)}-label`}
+                    >
+                        {renderFormattedValue({
+                            value: row[col.key],
+                            column: col,
+                            row,
+                            locale,
+                        })}
+                    </span>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/src/frontend/components/tool-ui/data-table/error-boundary.tsx
+++ b/src/frontend/components/tool-ui/data-table/error-boundary.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import {
+    ToolUIErrorBoundary,
+    type ToolUIErrorBoundaryProps,
+} from "../shared";
+
+export function DataTableErrorBoundary(
+    props: Omit<ToolUIErrorBoundaryProps, "componentName">,
+) {
+    const { children, ...rest } = props;
+    return (
+        <ToolUIErrorBoundary componentName="DataTable" {...rest}>
+            {children}
+        </ToolUIErrorBoundary>
+    );
+}

--- a/src/frontend/components/tool-ui/data-table/formatters.tsx
+++ b/src/frontend/components/tool-ui/data-table/formatters.tsx
@@ -1,0 +1,452 @@
+"use client";
+
+import * as React from "react";
+import { Badge, cn, Tooltip, TooltipContent, TooltipTrigger } from "./_adapter";
+
+type Tone = "success" | "warning" | "danger" | "info" | "neutral";
+
+export type FormatConfig =
+    | { kind: "text" }
+    | {
+        kind: "number";
+        decimals?: number;
+        unit?: string;
+        compact?: boolean;
+        showSign?: boolean;
+    }
+    | { kind: "currency"; currency: string; decimals?: number }
+    | {
+        kind: "percent";
+        decimals?: number;
+        showSign?: boolean;
+        basis?: "fraction" | "unit";
+    }
+    | { kind: "date"; dateFormat?: "short" | "long" | "relative" }
+    | {
+        kind: "delta";
+        decimals?: number;
+        upIsPositive?: boolean;
+        showSign?: boolean;
+    }
+    | {
+        kind: "status";
+        statusMap: Record<string, { tone: Tone; label?: string }>;
+    }
+    | { kind: "boolean"; labels?: { true: string; false: string } }
+    | { kind: "link"; hrefKey?: string; external?: boolean }
+    | { kind: "badge"; colorMap?: Record<string, Tone> }
+    | { kind: "array"; maxVisible?: number };
+
+interface DeltaValueProps {
+    value: number;
+    options?: Extract<FormatConfig, { kind: "delta" }>;
+}
+
+export function DeltaValue({ value, options }: DeltaValueProps) {
+    const decimals = options?.decimals ?? 2;
+    const upIsPositive = options?.upIsPositive ?? true;
+    const showSign = options?.showSign ?? true;
+
+    const isPositive = value > 0;
+    const isNegative = value < 0;
+    const isNeutral = value === 0;
+
+    const isGood = upIsPositive ? isPositive : isNegative;
+    const isBad = upIsPositive ? isNegative : isPositive;
+
+    const colorClass = isGood
+        ? "text-green-700 dark:text-green-500"
+        : isBad
+            ? "text-destructive"
+            : "text-muted-foreground";
+
+    const formatted = value.toFixed(decimals);
+    const display = showSign && !isNegative ? `+${formatted}` : formatted;
+
+    const arrow = isPositive ? "↑" : isNegative ? "↓" : "";
+
+    return (
+        <span className={cn("tabular-nums", colorClass)}>
+            {display}
+            {!isNeutral && <span className="ml-0.5">{arrow}</span>}
+        </span>
+    );
+}
+
+interface StatusBadgeProps {
+    value: string;
+    options?: Extract<FormatConfig, { kind: "status" }>;
+}
+
+export function StatusBadge({ value, options }: StatusBadgeProps) {
+    const config = options?.statusMap?.[value] ?? {
+        tone: "neutral" as Tone,
+        label: value,
+    };
+    const label = config.label ?? value;
+
+    const variant =
+        config.tone === "danger"
+            ? "destructive"
+            : config.tone === "neutral"
+                ? "outline"
+                : "secondary";
+
+    return (
+        <Badge
+            variant={variant}
+            className={cn(
+                "border",
+                config.tone === "warning" &&
+                "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-100",
+                config.tone === "success" &&
+                "bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-100",
+                config.tone === "info" &&
+                "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-100",
+                config.tone === "danger" &&
+                "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-100",
+            )}
+        >
+            {label}
+        </Badge>
+    );
+}
+
+interface CurrencyValueProps {
+    value: number;
+    options?: Extract<FormatConfig, { kind: "currency" }>;
+    locale?: string;
+}
+
+export function CurrencyValue({ value, options, locale }: CurrencyValueProps) {
+    const currency = options?.currency ?? "USD";
+    const decimals = options?.decimals ?? 2;
+
+    const formatted = new Intl.NumberFormat(locale, {
+        style: "currency",
+        currency,
+        minimumFractionDigits: decimals,
+        maximumFractionDigits: decimals,
+    }).format(value);
+
+    return <span className="tabular-nums">{formatted}</span>;
+}
+
+interface PercentValueProps {
+    value: number;
+    options?: Extract<FormatConfig, { kind: "percent" }>;
+}
+
+export function PercentValue({ value, options }: PercentValueProps) {
+    const decimals = options?.decimals ?? 2;
+    const showSign = options?.showSign ?? false;
+    const basis = options?.basis ?? "fraction";
+
+    const numeric = basis === "fraction" ? value * 100 : value;
+    const absoluteFormatted = Math.abs(numeric).toFixed(decimals);
+    const signed =
+        numeric > 0 && showSign
+            ? `+${absoluteFormatted}`
+            : numeric < 0
+                ? `-${absoluteFormatted}`
+                : absoluteFormatted;
+
+    return <span className="tabular-nums">{signed}%</span>;
+}
+
+interface DateValueProps {
+    value: string;
+    options?: Extract<FormatConfig, { kind: "date" }>;
+    locale?: string;
+}
+
+export function DateValue({ value, options, locale }: DateValueProps) {
+    const dateFormat = options?.dateFormat ?? "short";
+    const date = new Date(value);
+
+    if (isNaN(date.getTime())) {
+        return <span>Invalid date</span>;
+    }
+
+    let formatted: string;
+
+    if (dateFormat === "relative") {
+        formatted = getRelativeTime(date, locale);
+    } else if (dateFormat === "long") {
+        formatted = new Intl.DateTimeFormat(locale, {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+        }).format(date);
+    } else {
+        formatted = new Intl.DateTimeFormat(locale, {
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+        }).format(date);
+    }
+
+    const title = new Intl.DateTimeFormat(locale, {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+    }).format(date);
+
+    return (
+        <span className="tabular-nums" title={title}>
+            {formatted}
+        </span>
+    );
+}
+
+function getRelativeTime(date: Date, locale?: string): string {
+    const now = new Date();
+    const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+
+    if (diffInSeconds < 60) return "just now";
+    if (diffInSeconds < 3600) {
+        const mins = Math.floor(diffInSeconds / 60);
+        return `${mins} ${mins === 1 ? "minute" : "minutes"} ago`;
+    }
+    if (diffInSeconds < 86400) {
+        const hours = Math.floor(diffInSeconds / 3600);
+        return `${hours} ${hours === 1 ? "hour" : "hours"} ago`;
+    }
+    if (diffInSeconds < 604800) {
+        const days = Math.floor(diffInSeconds / 86400);
+        return `${days} ${days === 1 ? "day" : "days"} ago`;
+    }
+
+    return new Intl.DateTimeFormat(locale, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+    }).format(date);
+}
+
+interface BooleanValueProps {
+    value: boolean;
+    options?: Extract<FormatConfig, { kind: "boolean" }>;
+}
+
+export function BooleanValue({ value, options }: BooleanValueProps) {
+    const labels = options?.labels ?? { true: "Yes", false: "No" };
+    const label = value ? labels.true : labels.false;
+    const variant = value ? "secondary" : "outline";
+
+    return <Badge variant={variant}>{label}</Badge>;
+}
+
+interface LinkValueProps {
+    value: string;
+    options?: Extract<FormatConfig, { kind: "link" }>;
+    row?: Record<
+        string,
+        string | number | boolean | null | (string | number | boolean | null)[]
+    >;
+}
+
+export function LinkValue({ value, options, row }: LinkValueProps) {
+    const href =
+        options?.hrefKey && row ? String(row[options.hrefKey] ?? "") : value;
+    const external = options?.external ?? false;
+
+    if (!href) {
+        return <span>{value}</span>;
+    }
+
+    return (
+        <a
+            href={href}
+            target={external ? "_blank" : undefined}
+            rel={external ? "noopener noreferrer" : undefined}
+            className="text-accent-foreground inline-block max-w-full break-words underline underline-offset-2 hover:opacity-90"
+            aria-label={external ? `${value} (opens in a new tab)` : undefined}
+            onClick={(e) => e.stopPropagation()}
+        >
+            {value}
+            {external && (
+                <span className="ml-1 inline-block" aria-label="Opens in new tab">
+                    ↗
+                </span>
+            )}
+        </a>
+    );
+}
+
+interface NumberValueProps {
+    value: number;
+    options?: Extract<FormatConfig, { kind: "number" }>;
+    locale?: string;
+}
+
+export function NumberValue({ value, options, locale }: NumberValueProps) {
+    const decimals = options?.decimals ?? 0;
+    const unit = options?.unit ?? "";
+    const compact = options?.compact ?? false;
+    const showSign = options?.showSign ?? false;
+
+    const formatted = new Intl.NumberFormat(locale, {
+        minimumFractionDigits: decimals,
+        maximumFractionDigits: decimals,
+        notation: compact ? "compact" : "standard",
+    }).format(value);
+
+    const display = showSign && value > 0 ? `+${formatted}` : formatted;
+
+    return (
+        <span className="tabular-nums">
+            {display}
+            {unit}
+        </span>
+    );
+}
+
+interface BadgeValueProps {
+    value: string;
+    options?: Extract<FormatConfig, { kind: "badge" }>;
+}
+
+export function BadgeValue({ value, options }: BadgeValueProps) {
+    const tone = options?.colorMap?.[value] ?? "neutral";
+
+    const variant =
+        tone === "danger"
+            ? "destructive"
+            : tone === "neutral"
+                ? "outline"
+                : "secondary";
+
+    return (
+        <Badge
+            variant={variant}
+            className={cn(
+                "border",
+                tone === "warning" &&
+                "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-100",
+                tone === "success" &&
+                "bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-100",
+                tone === "info" &&
+                "bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-100",
+                tone === "danger" &&
+                "bg-red-100 text-red-700 dark:bg-red-950 dark:text-red-100",
+            )}
+        >
+            {value}
+        </Badge>
+    );
+}
+
+interface ArrayValueProps {
+    value: (string | number | boolean | null)[] | string;
+    options?: Extract<FormatConfig, { kind: "array" }>;
+}
+
+export function ArrayValue({ value, options }: ArrayValueProps) {
+    const maxVisible = options?.maxVisible ?? 3;
+    const items: (string | number | boolean | null)[] = Array.isArray(value)
+        ? value
+        : typeof value === "string"
+            ? value.split(",").map((s) => s.trim())
+            : [];
+
+    if (items.length === 0) {
+        return <span className="text-muted">—</span>;
+    }
+
+    const visible = items.slice(0, maxVisible);
+    const remaining = items.length - maxVisible;
+    const hidden = items.slice(maxVisible);
+
+    return (
+        <span className="inline-flex flex-wrap items-center gap-1">
+            {visible.map((item, i) => (
+                <span
+                    key={i}
+                    className="bg-muted text-muted-foreground inline-flex items-center rounded-md px-2 py-0.5"
+                >
+                    {item === null ? "null" : String(item)}
+                </span>
+            ))}
+            {remaining > 0 && (
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <span className="text-muted-foreground cursor-default">
+                            +{remaining} more
+                        </span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                        {hidden
+                            .map((item) => (item === null ? "null" : String(item)))
+                            .join(", ")}
+                    </TooltipContent>
+                </Tooltip>
+            )}
+        </span>
+    );
+}
+
+interface RenderFormattedValueParams {
+    value:
+    | string
+    | number
+    | boolean
+    | null
+    | (string | number | boolean | null)[];
+    column: { format?: FormatConfig };
+    row?: Record<
+        string,
+        string | number | boolean | null | (string | number | boolean | null)[]
+    >;
+    locale?: string;
+}
+
+export function renderFormattedValue({
+    value,
+    column,
+    row,
+    locale,
+}: RenderFormattedValueParams): React.ReactNode {
+    if (value == null || value === "") {
+        return <span className="text-muted">—</span>;
+    }
+
+    const fmt = column.format;
+
+    switch (fmt?.kind) {
+        case "delta":
+            return <DeltaValue value={Number(value)} options={fmt} />;
+        case "status":
+            return <StatusBadge value={String(value)} options={fmt} />;
+        case "currency":
+            return (
+                <CurrencyValue value={Number(value)} options={fmt} locale={locale} />
+            );
+        case "percent":
+            return <PercentValue value={Number(value)} options={fmt} />;
+        case "date":
+            return <DateValue value={String(value)} options={fmt} locale={locale} />;
+        case "boolean":
+            return <BooleanValue value={Boolean(value)} options={fmt} />;
+        case "link":
+            return <LinkValue value={String(value)} options={fmt} row={row} />;
+        case "number":
+            return (
+                <NumberValue value={Number(value)} options={fmt} locale={locale} />
+            );
+        case "badge":
+            return <BadgeValue value={String(value)} options={fmt} />;
+        case "array":
+            return (
+                <ArrayValue
+                    value={Array.isArray(value) ? value : String(value)}
+                    options={fmt}
+                />
+            );
+        case "text":
+        default:
+            return String(value);
+    }
+}

--- a/src/frontend/components/tool-ui/data-table/index.tsx
+++ b/src/frontend/components/tool-ui/data-table/index.tsx
@@ -1,0 +1,13 @@
+export { DataTable, useDataTable } from "./data-table";
+export { DataTableErrorBoundary } from "./error-boundary";
+
+export { ArrayValue, BadgeValue, BooleanValue, CurrencyValue, DateValue, DeltaValue, LinkValue, NumberValue, PercentValue, StatusBadge, renderFormattedValue } from "./formatters";
+export { parseSerializableDataTable } from "./schema";
+
+export type { FormatConfig } from "./formatters";
+export type {
+    Column, ColumnKey, DataTableClientProps, DataTableProps, DataTableRowData, DataTableSerializableProps, RowData, RowPrimitive
+} from "./types";
+
+export { parseNumericLike, sortData } from "./utilities";
+

--- a/src/frontend/components/tool-ui/data-table/schema.ts
+++ b/src/frontend/components/tool-ui/data-table/schema.ts
@@ -1,0 +1,231 @@
+import { z } from "zod";
+import {
+    ToolUIIdSchema,
+    ToolUIReceiptSchema,
+    ToolUIRoleSchema,
+    parseWithSchema,
+} from "../shared";
+import type { Column, DataTableProps, RowData } from "./types";
+
+const AlignEnum = z.enum(["left", "right", "center"]);
+const PriorityEnum = z.enum(["primary", "secondary", "tertiary"]);
+
+const formatSchema = z.discriminatedUnion("kind", [
+    z.object({ kind: z.literal("text") }),
+    z.object({
+        kind: z.literal("number"),
+        decimals: z.number().optional(),
+        unit: z.string().optional(),
+        compact: z.boolean().optional(),
+        showSign: z.boolean().optional(),
+    }),
+    z.object({
+        kind: z.literal("currency"),
+        currency: z.string(),
+        decimals: z.number().optional(),
+    }),
+    z.object({
+        kind: z.literal("percent"),
+        decimals: z.number().optional(),
+        showSign: z.boolean().optional(),
+        basis: z.enum(["fraction", "unit"]).optional(),
+    }),
+    z.object({
+        kind: z.literal("date"),
+        dateFormat: z.enum(["short", "long", "relative"]).optional(),
+    }),
+    z.object({
+        kind: z.literal("delta"),
+        decimals: z.number().optional(),
+        upIsPositive: z.boolean().optional(),
+        showSign: z.boolean().optional(),
+    }),
+    z.object({
+        kind: z.literal("status"),
+        statusMap: z.record(
+            z.string(),
+            z.object({
+                tone: z.enum(["success", "warning", "danger", "info", "neutral"]),
+                label: z.string().optional(),
+            }),
+        ),
+    }),
+    z.object({
+        kind: z.literal("boolean"),
+        labels: z
+            .object({
+                true: z.string(),
+                false: z.string(),
+            })
+            .optional(),
+    }),
+    z.object({
+        kind: z.literal("link"),
+        hrefKey: z.string().optional(),
+        external: z.boolean().optional(),
+    }),
+    z.object({
+        kind: z.literal("badge"),
+        colorMap: z
+            .record(
+                z.string(),
+                z.enum(["success", "warning", "danger", "info", "neutral"]),
+            )
+            .optional(),
+    }),
+    z.object({
+        kind: z.literal("array"),
+        maxVisible: z.number().optional(),
+    }),
+]);
+
+export const serializableColumnSchema = z.object({
+    key: z.string(),
+    label: z.string(),
+    abbr: z.string().optional(),
+    sortable: z.boolean().optional(),
+    align: AlignEnum.optional(),
+    width: z.string().optional(),
+    truncate: z.boolean().optional(),
+    priority: PriorityEnum.optional(),
+    hideOnMobile: z.boolean().optional(),
+    format: formatSchema.optional(),
+});
+
+const JsonPrimitiveSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
+
+/**
+ * Schema for serializable row data.
+ *
+ * Supports:
+ * - Primitives: string, number, boolean, null
+ * - Arrays of primitives: string[], number[], boolean[], or mixed primitive arrays
+ *
+ * Does NOT support:
+ * - Functions
+ * - Class instances (Date, Map, Set, etc.)
+ * - Plain objects (use format configs instead)
+ *
+ * @example
+ * Valid row data:
+ * ```json
+ * {
+ *   "name": "Widget",
+ *   "price": 29.99,
+ *   "active": true,
+ *   "tags": ["electronics", "featured"],
+ *   "metrics": [1.2, 3.4, 5.6],
+ *   "flags": [true, false, true],
+ *   "mixed": ["label", 42, true]
+ * }
+ * ```
+ */
+export const serializableDataSchema = z.record(
+    z.string(),
+    z.union([JsonPrimitiveSchema, z.array(JsonPrimitiveSchema)]),
+);
+
+/**
+ * Zod schema for validating DataTable payloads from LLM tool calls.
+ *
+ * This schema validates the serializable parts of a DataTable:
+ * - id: Unique identifier for this tool UI in the conversation
+ * - columns: Column definitions (keys, labels, formatting, etc.)
+ * - data: Data rows (primitives only - no functions or class instances)
+ * - layout: Optional layout override ('auto' | 'table' | 'cards')
+ *
+ * Non-serializable props like `onSortChange`, `className`, and response actions
+ * must be provided separately in your React component.
+ *
+ * @example
+ * ```ts
+ * const result = SerializableDataTableSchema.safeParse(llmResponse)
+ * if (result.success) {
+ *   // result.data contains validated id, columns, and data
+ * }
+ * ```
+ */
+export const SerializableDataTableSchema = z.object({
+    id: ToolUIIdSchema,
+    role: ToolUIRoleSchema.optional(),
+    receipt: ToolUIReceiptSchema.optional(),
+    columns: z.array(serializableColumnSchema),
+    data: z.array(serializableDataSchema),
+});
+
+/**
+ * Type representing the serializable parts of a DataTable payload.
+ *
+ * This type includes only JSON-serializable data that can come from LLM tool calls:
+ * - Column definitions (format configs, alignment, labels, etc.)
+ * - Row data (primitives: strings, numbers, booleans, null, string arrays)
+ *
+ * Excluded from this type:
+ * - Event handlers (`onSortChange`, `onResponseAction`)
+ * - React-specific props (`className`, `responseActions`)
+ *
+ * @example
+ * ```ts
+ * const payload: SerializableDataTable = {
+ *   id: "data-table-expenses",
+ *   columns: [
+ *     { key: "name", label: "Name" },
+ *     { key: "price", label: "Price", format: { kind: "currency", currency: "USD" } }
+ *   ],
+ *   data: [
+ *     { name: "Widget", price: 29.99 }
+ *   ]
+ * }
+ * ```
+ */
+export type SerializableDataTable = z.infer<typeof SerializableDataTableSchema>;
+
+/**
+ * Validates and parses a DataTable payload from unknown data (e.g., LLM tool call result).
+ *
+ * This function:
+ * 1. Validates the input against the `SerializableDataTableSchema`
+ * 2. Throws a descriptive error if validation fails
+ * 3. Returns typed serializable props ready to pass to the `<DataTable>` component
+ *
+ * The returned props are **serializable only** - you must provide client-side props
+ * separately (onSortChange, className, responseActions, onResponseAction).
+ *
+ * @param input - Unknown data to validate (typically from an LLM tool call)
+ * @returns Validated and typed DataTable serializable props (id, columns, data)
+ * @throws Error with validation details if input is invalid
+ *
+ * @example
+ * ```tsx
+ * function MyToolUI({ result }: { result: unknown }) {
+ *   const serializableProps = parseSerializableDataTable(result)
+ *
+ *   return (
+ *     <DataTable
+ *       {...serializableProps}
+ *       responseActions={[{ id: "export", label: "Export" }]}
+ *       onResponseAction={(id) => console.log(id)}
+ *     />
+ *   )
+ * }
+ * ```
+ */
+export function parseSerializableDataTable(
+    input: unknown,
+): Pick<
+    DataTableProps<RowData>,
+    "id" | "role" | "receipt" | "columns" | "data"
+> {
+    const { id, role, receipt, columns, data } = parseWithSchema(
+        SerializableDataTableSchema,
+        input,
+        "DataTable",
+    );
+    return {
+        id,
+        role,
+        receipt,
+        columns: columns as unknown as Column<RowData>[],
+        data: data as RowData[],
+    };
+}

--- a/src/frontend/components/tool-ui/data-table/types.ts
+++ b/src/frontend/components/tool-ui/data-table/types.ts
@@ -1,0 +1,275 @@
+import type {
+    ActionsProp,
+    ToolUIId,
+    ToolUIReceipt,
+    ToolUIRole,
+} from "../shared";
+import type { FormatConfig } from "./formatters";
+
+/**
+ * JSON primitive type that can be serialized.
+ */
+type JsonPrimitive = string | number | boolean | null;
+
+/**
+ * Valid row value types for serializable DataTable data.
+ *
+ * Supports:
+ * - Primitives: string, number, boolean, null
+ * - Arrays of primitives: string[], number[], boolean[], or mixed primitive arrays
+ *
+ * For complex data (objects with href/label, etc.), use column format configs
+ * instead of putting objects in row data.
+ *
+ * @example
+ * ```ts
+ * // 👍 Good: Use primitives and primitive arrays
+ * const row = {
+ *   name: "Widget",
+ *   price: 29.99,
+ *   tags: ["electronics", "featured"],
+ *   metrics: [1.2, 3.4, 5.6]
+ * }
+ *
+ * // 🚫 Bad: Don't put objects in row data
+ * const row = {
+ *   link: { href: "/path", label: "Click" }  // Use format: { kind: 'link' } instead
+ * }
+ * ```
+ */
+export type RowPrimitive = JsonPrimitive | JsonPrimitive[];
+export type DataTableRowData = Record<string, RowPrimitive>;
+export type RowData = Record<string, unknown>;
+export type ColumnKey<T extends object> = Extract<keyof T, string>;
+
+export type FormatFor<V> = V extends number
+    ? Extract<FormatConfig, { kind: "number" | "currency" | "percent" | "delta" }>
+    : V extends boolean
+    ? Extract<FormatConfig, { kind: "boolean" | "status" | "badge" }>
+    : V extends (string | number | boolean | null)[]
+    ? Extract<FormatConfig, { kind: "array" }>
+    : V extends string
+    ? Extract<
+        FormatConfig,
+        { kind: "text" | "link" | "date" | "badge" | "status" }
+    >
+    : Extract<FormatConfig, { kind: "text" }>;
+
+/**
+ * Column definition for DataTable
+ *
+ * @remarks
+ * **Important:** Columns are sortable by default (opt-out pattern).
+ * Set `sortable: false` explicitly to disable sorting for specific columns.
+ */
+export interface Column<
+    T extends object = DataTableRowData,
+    K extends ColumnKey<T> = ColumnKey<T>,
+> {
+    /** Unique identifier that maps to a key in the row data */
+    key: K;
+    /** Display text for the column header */
+    label: string;
+    /** Abbreviated label for narrow viewports */
+    abbr?: string;
+    /** Whether column is sortable. Default: true (opt-out pattern) */
+    sortable?: boolean;
+    /** Text alignment for column cells */
+    align?: "left" | "right" | "center";
+    /** Optional fixed width (CSS value) */
+    width?: string;
+    /** Enable text truncation with ellipsis */
+    truncate?: boolean;
+    /** Mobile display priority (primary = always visible, secondary = expandable, tertiary = hidden) */
+    priority?: "primary" | "secondary" | "tertiary";
+    /** Completely hide column on mobile viewports */
+    hideOnMobile?: boolean;
+    /** Formatting configuration for cell values */
+    format?: FormatFor<T[K]>;
+}
+
+/**
+ * Serializable props that can come from LLM tool calls or be JSON-serialized.
+ *
+ * These props contain only primitive values, arrays, and plain objects -
+ * no functions, class instances, or other non-serializable values.
+ *
+ * @example
+ * ```tsx
+ * const serializableProps: DataTableSerializableProps = {
+ *   columns: [...],
+ *   data: [...],
+ *   rowIdKey: "id",
+ *   defaultSort: { by: "price", direction: "desc" }
+ * }
+ * ```
+ */
+export interface DataTableSerializableProps<T extends object = RowData> {
+    /**
+     * Unique identifier for this tool UI instance in the conversation.
+     *
+     * Used for:
+     * - Assistant referencing ("the table above")
+     * - Receipt generation (linking actions to their source)
+     * - Narration context
+     *
+     * Should be stable across re-renders, meaningful, and unique within the conversation.
+     *
+     * @example "data-table-expenses-q3", "search-results-repos"
+     */
+    id: ToolUIId;
+    /** Optional surface role metadata (serializable) */
+    role?: ToolUIRole;
+    /** Optional receipt metadata for consequential outcomes (serializable) */
+    receipt?: ToolUIReceipt;
+    /** Column definitions */
+    columns: Column<T>[];
+    /** Row data (primitives only - no functions or class instances) */
+    data: T[];
+    /**
+     * Key in row data to use as unique identifier for React keys
+     *
+     * **Strongly recommended:** Always provide this for dynamic data to prevent
+     * reconciliation issues (focus traps, animation glitches, incorrect state preservation)
+     * when data reorders. Falls back to array index if omitted (only acceptable for static mock data).
+     *
+     * @example rowIdKey="id" or rowIdKey="uuid"
+     */
+    rowIdKey?: ColumnKey<T>;
+    /**
+     * Uncontrolled initial sort state (table manages its own sort state internally)
+     *
+     * **Sorting cycle:** Clicking column headers cycles through tri-state:
+     * 1. none (unsorted) → 2. asc → 3. desc → 4. none (back to unsorted)
+     *
+     * @example
+     * ```tsx
+     * // Start with descending price sort
+     * <DataTable defaultSort={{ by: "price", direction: "desc" }} />
+     * ```
+     */
+    defaultSort?: { by?: ColumnKey<T>; direction?: "asc" | "desc" };
+    /**
+     * Controlled sort state (use with onSortChange from client props)
+     *
+     * When provided, you must also provide `onSortChange` to handle sort updates.
+     * The table will cycle through: none → asc → desc → none.
+     *
+     * @example
+     * ```tsx
+     * const [sort, setSort] = useState({ by: "price", direction: "desc" })
+     * <DataTable sort={sort} onSortChange={setSort} />
+     * ```
+     */
+    sort?: { by?: ColumnKey<T>; direction?: "asc" | "desc" };
+    /** Empty state message */
+    emptyMessage?: string;
+    /** Max table height with vertical scroll (CSS value) */
+    maxHeight?: string;
+    /**
+     * BCP47 locale for formatting and sorting (e.g., 'en-US', 'de-DE', 'ja-JP')
+     *
+     * Defaults to 'en-US' to ensure consistent server/client rendering.
+     * Pass explicit locale for internationalization.
+     *
+     * @example
+     * ```tsx
+     * <DataTable locale="de-DE" /> // German formatting
+     * <DataTable locale="ja-JP" /> // Japanese formatting
+     * <DataTable />               // Uses 'en-US' default
+     * ```
+     */
+    locale?: string;
+}
+
+/**
+ * Client-side React-only props that cannot be serialized.
+ *
+ * These props contain functions, component state, or other React-specific values
+ * that must be provided by your React code (not from LLM tool calls).
+ *
+ * @example
+ * ```tsx
+ * const clientProps: DataTableClientProps = {
+ *   className: "my-table",
+ *   onSortChange: (next) => setSort(next),
+ *   responseActions: [{ id: "export", label: "Export" }],
+ *   onResponseAction: (id) => console.log(id)
+ * }
+ * ```
+ */
+export interface DataTableClientProps<T extends object = RowData> {
+    /** Additional CSS classes */
+    className?: string;
+    /**
+     * Sort change handler for controlled mode (required if sort is provided)
+     *
+     * **Tri-state cycle behavior:**
+     * - Click unsorted column: `{ by: "column", direction: "asc" }`
+     * - Click asc column: `{ by: "column", direction: "desc" }`
+     * - Click desc column: `{ by: "column", direction: undefined }` (returns to unsorted)
+     * - Click different column: `{ by: "newColumn", direction: "asc" }`
+     *
+     * @example
+     * ```tsx
+     * const [sort, setSort] = useState<{ by?: string; direction?: "asc" | "desc" }>({})
+     *
+     * <DataTable
+     *   sort={sort}
+     *   onSortChange={(next) => {
+     *     console.log("Sort changed:", next)
+     *     setSort(next)
+     *   }}
+     * />
+     * ```
+     */
+    onSortChange?: (next: {
+        by?: ColumnKey<T>;
+        direction?: "asc" | "desc";
+    }) => void;
+    /** Optional response actions rendered below the table */
+    responseActions?: ActionsProp;
+    /** Callback when a response action is triggered */
+    onResponseAction?: (actionId: string) => void | Promise<void>;
+    /** Optional guard before executing a response action */
+    onBeforeResponseAction?: (actionId: string) => boolean | Promise<boolean>;
+}
+
+/**
+ * Complete props for the DataTable component.
+ *
+ * Combines serializable props (can come from LLM tool calls) with client-side
+ * React-only props. This separation makes the boundary explicit and prevents
+ * accidental serialization of non-serializable values.
+ *
+ * @see {@link DataTableSerializableProps} for props that can be JSON-serialized
+ * @see {@link DataTableClientProps} for React-only props
+ * @see {@link parseSerializableDataTable} for parsing LLM tool call results
+ *
+ * @example
+ * ```tsx
+ * // From LLM tool call
+ * const serializableProps = parseSerializableDataTable(llmResult)
+ *
+ * // Combine with React-specific props
+ * <DataTable
+ *   {...serializableProps}
+ *   onSortChange={setSort}
+ *   responseActions={[{ id: "export", label: "Export" }]}
+ *   onResponseAction={(id) => handleAction(id)}
+ * />
+ * ```
+ */
+export interface DataTableProps<T extends object = RowData>
+    extends DataTableSerializableProps<T>, DataTableClientProps<T> { }
+
+export interface DataTableContextValue<T extends object = RowData> {
+    columns: Column<T>[];
+    data: T[];
+    rowIdKey?: ColumnKey<T>;
+    sortBy?: ColumnKey<T>;
+    sortDirection?: "asc" | "desc";
+    toggleSort?: (key: ColumnKey<T>) => void;
+    id?: string;
+    locale?: string;
+}

--- a/src/frontend/components/tool-ui/data-table/utilities.ts
+++ b/src/frontend/components/tool-ui/data-table/utilities.ts
@@ -1,0 +1,187 @@
+/**
+ * Sort an array of objects by a key
+ */
+export function sortData<T, K extends Extract<keyof T, string>>(
+    data: T[],
+    key: K,
+    direction: "asc" | "desc",
+    locale?: string,
+): T[] {
+    const get = (obj: T, k: K): unknown => (obj as Record<string, unknown>)[k];
+    const collator = new Intl.Collator(locale, {
+        numeric: true,
+        sensitivity: "base",
+    });
+    return [...data].sort((a, b) => {
+        const aVal = get(a, key);
+        const bVal = get(b, key);
+
+        // Handle nulls
+        if (aVal == null && bVal == null) return 0;
+        if (aVal == null) return 1;
+        if (bVal == null) return -1;
+
+        // Type-specific comparison
+        // Numbers
+        if (typeof aVal === "number" && typeof bVal === "number") {
+            return direction === "asc" ? aVal - bVal : bVal - aVal;
+        }
+        // Dates (Date instances)
+        if (aVal instanceof Date && bVal instanceof Date) {
+            const diff = aVal.getTime() - bVal.getTime();
+            return direction === "asc" ? diff : -diff;
+        }
+        // Booleans: false < true
+        if (typeof aVal === "boolean" && typeof bVal === "boolean") {
+            const diff = aVal === bVal ? 0 : aVal ? 1 : -1;
+            return direction === "asc" ? diff : -diff;
+        }
+        // Arrays: compare length
+        if (Array.isArray(aVal) && Array.isArray(bVal)) {
+            const diff = aVal.length - bVal.length;
+            return direction === "asc" ? diff : -diff;
+        }
+        // Strings that look like numbers -> numeric compare
+        if (typeof aVal === "string" && typeof bVal === "string") {
+            const numA = parseNumericLike(aVal);
+            const numB = parseNumericLike(bVal);
+            if (numA != null && numB != null) {
+                const diff = numA - numB;
+                return direction === "asc" ? diff : -diff;
+            }
+            // ISO-like date strings
+            if (/^\d{4}-\d{2}-\d{2}/.test(aVal) && /^\d{4}-\d{2}-\d{2}/.test(bVal)) {
+                const da = new Date(aVal).getTime();
+                const db = new Date(bVal).getTime();
+                const diff = da - db;
+                return direction === "asc" ? diff : -diff;
+            }
+        }
+
+        // Fallback: locale-aware string compare with numeric collation
+        const aStr = String(aVal);
+        const bStr = String(bVal);
+        const comparison = collator.compare(aStr, bStr);
+        return direction === "asc" ? comparison : -comparison;
+    });
+}
+
+/**
+ * Return a human-friendly identifier for a row using common keys
+ *
+ * Accepts any JSON-serializable primitive or array of primitives.
+ * Arrays are converted to comma-separated strings.
+ */
+export function getRowIdentifier(
+    row: Record<
+        string,
+        string | number | boolean | null | (string | number | boolean | null)[]
+    >,
+    identifierKey?: string,
+): string {
+    const candidate =
+        (identifierKey ? row[identifierKey] : undefined) ??
+        (row as Record<string, unknown>).name ??
+        (row as Record<string, unknown>).title ??
+        (row as Record<string, unknown>).id;
+
+    if (candidate == null) {
+        return "";
+    }
+
+    // Handle arrays by joining them
+    if (Array.isArray(candidate)) {
+        return candidate.map((v) => (v === null ? "null" : String(v))).join(", ");
+    }
+
+    return String(candidate).trim();
+}
+
+/**
+ * Parse a string that represents a numeric value, handling various formats:
+ * - Currency symbols: $, €, £, ¥, etc.
+ * - Percent symbols: %
+ * - Accounting negatives: (1234) → -1234
+ * - Thousands/decimal separators: 1,234.56 or 1.234,56
+ * - Compact notation: 2.8T (trillion), 1.5M (million), 500K (thousand)
+ * - Byte suffixes: 768B (bytes), 1.5KB, 2GB, 1TB
+ *
+ * Note: Single "B" is disambiguated - integers < 1024 are bytes, otherwise billions.
+ *
+ * @param input - String to parse
+ * @returns Parsed number or null if unparseable
+ *
+ * @example
+ * parseNumericLike("$1,234.56") // 1234.56
+ * parseNumericLike("2.8T") // 2800000000000
+ * parseNumericLike("768B") // 768
+ * parseNumericLike("50%") // 50
+ * parseNumericLike("(1234)") // -1234
+ */
+export function parseNumericLike(input: string): number | null {
+    // Normalize whitespace (spaces, NBSPs, thin spaces)
+    let s = input.replace(/[\u00A0\u202F\s]/g, "").trim();
+    if (!s) return null;
+
+    // Accounting negatives: (1234) -> -1234
+    s = s.replace(/^\((.*)\)$/g, "-$1");
+
+    // Strip common currency and percent symbols
+    s = s.replace(/[\%$€£¥₩₹₽₺₪₫฿₦₴₡₲₵₸]/g, "");
+
+    const lastComma = s.lastIndexOf(",");
+    const lastDot = s.lastIndexOf(".");
+    if (lastComma !== -1 && lastDot !== -1) {
+        // Decide decimal by whichever occurs last
+        const decimalSep = lastComma > lastDot ? "," : ".";
+        const thousandSep = decimalSep === "," ? "." : ",";
+        s = s.split(thousandSep).join("");
+        s = s.replace(decimalSep, ".");
+    } else if (lastComma !== -1) {
+        // Only comma present
+        const frac = s.length - lastComma - 1;
+        if (frac === 2 || frac === 3) s = s.replace(/,/g, ".");
+        else s = s.replace(/,/g, "");
+    } else if (lastDot !== -1) {
+        // Only dot present; if multiple dots, treat as thousands and strip
+        if ((s.match(/\./g) || []).length > 1) s = s.replace(/\./g, "");
+    }
+
+    // Handle compact notation (K, M, B, T, P, G) and byte suffixes (KB, MB, GB, TB, PB)
+    const compactMatch = s.match(/^([+-]?\d+\.?\d*|\d*\.\d+)([KMBTPG]B?|B)$/i);
+    if (compactMatch) {
+        const baseNum = Number(compactMatch[1]);
+        if (Number.isNaN(baseNum)) return null;
+
+        const suffix = compactMatch[2].toUpperCase();
+
+        // Disambiguate single "B" (bytes vs billions)
+        // If whole number < 1024, treat as bytes. Otherwise, billions.
+        if (suffix === "B") {
+            const isLikelyBytes = Number.isInteger(baseNum) && baseNum < 1024;
+            return isLikelyBytes ? baseNum : baseNum * 1e9;
+        }
+
+        const multipliers: Record<string, number> = {
+            K: 1e3,
+            KB: 1024, // Kilo: metric vs binary
+            M: 1e6,
+            MB: 1024 ** 2, // Mega
+            G: 1e9,
+            GB: 1024 ** 3, // Giga
+            T: 1e12,
+            TB: 1024 ** 4, // Tera
+            P: 1e15,
+            PB: 1024 ** 5, // Peta
+        };
+
+        return baseNum * (multipliers[suffix] ?? 1);
+    }
+
+    if (/^[+-]?(?:\d+\.?\d*|\d*\.\d+)$/.test(s)) {
+        const n = Number(s);
+        return Number.isNaN(n) ? null : n;
+    }
+
+    return null;
+}

--- a/src/frontend/components/tool-ui/shared/_adapter.tsx
+++ b/src/frontend/components/tool-ui/shared/_adapter.tsx
@@ -1,0 +1,13 @@
+/**
+ * Adapter: UI and utility re-exports for copy-standalone portability.
+ *
+ * When copying this component to another project, update these imports
+ * to match your project's paths:
+ *
+ *   cn     → Your Tailwind merge utility (e.g., "@/lib/utils", "~/lib/cn")
+ *   Button → shadcn/ui Button
+ */
+
+export { cn } from "@/lib/utils";
+export { Button } from "../../ui/button";
+

--- a/src/frontend/components/tool-ui/shared/action-buttons.tsx
+++ b/src/frontend/components/tool-ui/shared/action-buttons.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { Button, cn } from "./_adapter";
+import type { Action } from "./schema";
+import { useActionButtons } from "./use-action-buttons";
+
+export interface ActionButtonsProps {
+    actions: Action[];
+    onAction: (actionId: string) => void | Promise<void>;
+    onBeforeAction?: (actionId: string) => boolean | Promise<boolean>;
+    confirmTimeout?: number;
+    align?: "left" | "center" | "right";
+    className?: string;
+}
+
+export function ActionButtons({
+    actions,
+    onAction,
+    onBeforeAction,
+    confirmTimeout = 3000,
+    align = "right",
+    className,
+}: ActionButtonsProps) {
+    const { actions: resolvedActions, runAction } = useActionButtons({
+        actions,
+        onAction,
+        onBeforeAction,
+        confirmTimeout,
+    });
+
+    return (
+        <div
+            className={cn(
+                "flex flex-col gap-3",
+                "@sm/actions:flex-row @sm/actions:flex-wrap @sm/actions:items-center @sm/actions:gap-2",
+                align === "left" && "@sm/actions:justify-start",
+                align === "center" && "@sm/actions:justify-center",
+                align === "right" && "@sm/actions:justify-end",
+                className,
+            )}
+        >
+            {resolvedActions.map((action) => {
+                const label = action.currentLabel;
+                const variant = action.variant || "default";
+
+                return (
+                    <Button
+                        key={action.id}
+                        variant={variant}
+                        onClick={() => runAction(action.id)}
+                        disabled={action.isDisabled}
+                        className={cn(
+                            "rounded-full px-4!",
+                            "justify-center",
+                            "min-h-11 w-full text-base",
+                            "@sm/actions:min-h-0 @sm/actions:w-auto @sm/actions:px-3 @sm/actions:py-2 @sm/actions:text-sm",
+                            action.isConfirming &&
+                            "ring-destructive ring-2 ring-offset-2 motion-safe:animate-pulse",
+                        )}
+                        aria-label={
+                            action.shortcut ? `${label} (${action.shortcut})` : label
+                        }
+                    >
+                        {action.isLoading && (
+                            <svg
+                                className="mr-2 h-4 w-4 motion-safe:animate-spin"
+                                xmlns="http://www.w3.org/2000/svg"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                            >
+                                <circle
+                                    className="opacity-25"
+                                    cx="12"
+                                    cy="12"
+                                    r="10"
+                                    stroke="currentColor"
+                                    strokeWidth="4"
+                                />
+                                <path
+                                    className="opacity-75"
+                                    fill="currentColor"
+                                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                                />
+                            </svg>
+                        )}
+                        {action.icon && !action.isLoading && (
+                            <span className="mr-2">{action.icon}</span>
+                        )}
+                        {label}
+                        {action.shortcut && !action.isLoading && (
+                            <kbd className="border-border bg-muted ml-2.5 hidden rounded-lg border px-2 py-0.5 font-mono text-xs font-medium sm:inline-block">
+                                {action.shortcut}
+                            </kbd>
+                        )}
+                    </Button>
+                );
+            })}
+        </div>
+    );
+}

--- a/src/frontend/components/tool-ui/shared/actions-config.ts
+++ b/src/frontend/components/tool-ui/shared/actions-config.ts
@@ -1,0 +1,48 @@
+import type { Action, ActionsConfig } from "./schema";
+
+export type ActionsProp = ActionsConfig | Action[];
+
+const NEGATORY_ACTION_IDS = new Set([
+    "cancel",
+    "dismiss",
+    "skip",
+    "no",
+    "reset",
+    "close",
+    "decline",
+    "reject",
+    "back",
+    "later",
+    "not-now",
+    "maybe-later",
+]);
+
+function inferVariant(action: Action): Action {
+    if (action.variant) return action;
+    if (NEGATORY_ACTION_IDS.has(action.id)) {
+        return { ...action, variant: "ghost" };
+    }
+    return action;
+}
+
+export function normalizeActionsConfig(
+    actions?: ActionsProp,
+): ActionsConfig | null {
+    if (!actions) return null;
+
+    const rawItems = Array.isArray(actions) ? actions : (actions.items ?? []);
+
+    if (rawItems.length === 0) {
+        return null;
+    }
+
+    const items = rawItems.map(inferVariant);
+
+    return Array.isArray(actions)
+        ? { items }
+        : {
+            items,
+            align: actions.align,
+            confirmTimeout: actions.confirmTimeout,
+        };
+}

--- a/src/frontend/components/tool-ui/shared/error-boundary.tsx
+++ b/src/frontend/components/tool-ui/shared/error-boundary.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import * as React from "react";
+
+export interface ToolUIErrorBoundaryProps {
+    componentName: string;
+    children: React.ReactNode;
+    fallback?: React.ReactNode;
+    onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
+}
+
+interface ToolUIErrorBoundaryState {
+    hasError: boolean;
+    error?: Error;
+}
+
+export class ToolUIErrorBoundary extends React.Component<
+    ToolUIErrorBoundaryProps,
+    ToolUIErrorBoundaryState
+> {
+    constructor(props: ToolUIErrorBoundaryProps) {
+        super(props);
+        this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError(error: Error): ToolUIErrorBoundaryState {
+        return { hasError: true, error };
+    }
+
+    componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+        console.error(`[${this.props.componentName}] render error:`, error, errorInfo);
+        this.props.onError?.(error, errorInfo);
+    }
+
+    render() {
+        if (this.state.hasError) {
+            return (
+                this.props.fallback ?? (
+                    <div className="border-destructive text-destructive rounded-lg border p-4">
+                        <p className="font-semibold">
+                            {this.props.componentName} failed to render
+                        </p>
+                        <p className="text-sm">{this.state.error?.message}</p>
+                    </div>
+                )
+            );
+        }
+        return this.props.children;
+    }
+}

--- a/src/frontend/components/tool-ui/shared/index.ts
+++ b/src/frontend/components/tool-ui/shared/index.ts
@@ -1,0 +1,9 @@
+export { ActionButtons } from "./action-buttons";
+export type { ActionButtonsProps } from "./action-buttons";
+export { normalizeActionsConfig, type ActionsProp } from "./actions-config";
+export * from "./error-boundary";
+export * from "./parse";
+export * from "./schema";
+export * from "./use-copy-to-clipboard";
+export * from "./utils";
+

--- a/src/frontend/components/tool-ui/shared/parse.ts
+++ b/src/frontend/components/tool-ui/shared/parse.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+function formatZodPath(path: Array<string | number | symbol>): string {
+    if (path.length === 0) return "root";
+    return path
+        .map((segment) =>
+            typeof segment === "number" ? `[${segment}]` : String(segment),
+        )
+        .join(".");
+}
+
+/**
+ * Format Zod errors into a compact `path: message` string.
+ */
+export function formatZodError(error: z.ZodError): string {
+    const parts = error.issues.map((issue) => {
+        const path = formatZodPath(issue.path);
+        return `${path}: ${issue.message}`;
+    });
+
+    return Array.from(new Set(parts)).join("; ");
+}
+
+/**
+ * Parse unknown input and throw a readable error.
+ */
+export function parseWithSchema<T>(
+    schema: z.ZodType<T>,
+    input: unknown,
+    name: string,
+): T {
+    const res = schema.safeParse(input);
+    if (!res.success) {
+        throw new Error(`Invalid ${name} payload: ${formatZodError(res.error)}`);
+    }
+    return res.data;
+}

--- a/src/frontend/components/tool-ui/shared/schema.ts
+++ b/src/frontend/components/tool-ui/shared/schema.ts
@@ -1,0 +1,122 @@
+import type { ReactNode } from "react";
+import { z } from "zod";
+
+/**
+ * Tool UI conventions:
+ * - Serializable schemas are JSON-safe (no callbacks/ReactNode/`className`).
+ * - Schema: `SerializableXSchema`
+ * - Parser: `parseSerializableX(input: unknown)`
+ * - Actions: `responseActions`, `onResponseAction`, `onBeforeResponseAction`
+ * - Root attrs: `data-tool-ui-id` + `data-slot`
+ */
+
+/**
+ * Schema for tool UI identity.
+ *
+ * Every tool UI should have a unique identifier that:
+ * - Is stable across re-renders
+ * - Is meaningful (not auto-generated)
+ * - Is unique within the conversation
+ *
+ * Format recommendation: `{component-type}-{semantic-identifier}`
+ * Examples: "data-table-expenses-q3", "option-list-deploy-target"
+ */
+export const ToolUIIdSchema = z.string().min(1);
+
+export type ToolUIId = z.infer<typeof ToolUIIdSchema>;
+
+/**
+ * Primary role of a Tool UI surface in a chat context.
+ */
+export const ToolUIRoleSchema = z.enum([
+    "information",
+    "decision",
+    "control",
+    "state",
+    "composite",
+]);
+
+export type ToolUIRole = z.infer<typeof ToolUIRoleSchema>;
+
+export const ToolUIReceiptOutcomeSchema = z.enum([
+    "success",
+    "partial",
+    "failed",
+    "cancelled",
+]);
+
+export type ToolUIReceiptOutcome = z.infer<typeof ToolUIReceiptOutcomeSchema>;
+
+/**
+ * Optional receipt metadata: a durable summary of an outcome.
+ */
+export const ToolUIReceiptSchema = z.object({
+    outcome: ToolUIReceiptOutcomeSchema,
+    summary: z.string().min(1),
+    identifiers: z.record(z.string(), z.string()).optional(),
+    at: z.string().datetime(),
+});
+
+export type ToolUIReceipt = z.infer<typeof ToolUIReceiptSchema>;
+
+/**
+ * Base schema for Tool UI payloads (id + optional role/receipt).
+ */
+export const ToolUISurfaceSchema = z.object({
+    id: ToolUIIdSchema,
+    role: ToolUIRoleSchema.optional(),
+    receipt: ToolUIReceiptSchema.optional(),
+});
+
+export type ToolUISurface = z.infer<typeof ToolUISurfaceSchema>;
+
+export const ActionSchema = z.object({
+    id: z.string().min(1),
+    label: z.string().min(1),
+    /**
+     * Canonical narration the assistant can use after this action is taken.
+     *
+     * Example: "I exported the table as CSV." / "I opened the link in a new tab."
+     */
+    sentence: z.string().optional(),
+    confirmLabel: z.string().optional(),
+    variant: z
+        .enum(["default", "destructive", "secondary", "ghost", "outline"])
+        .optional(),
+    icon: z.custom<ReactNode>().optional(),
+    loading: z.boolean().optional(),
+    disabled: z.boolean().optional(),
+    shortcut: z.string().optional(),
+});
+
+export type Action = z.infer<typeof ActionSchema>;
+
+export const ActionButtonsPropsSchema = z.object({
+    actions: z.array(ActionSchema).min(1),
+    align: z.enum(["left", "center", "right"]).optional(),
+    confirmTimeout: z.number().positive().optional(),
+    className: z.string().optional(),
+});
+
+export const SerializableActionSchema = ActionSchema.omit({ icon: true });
+export const SerializableActionsSchema = ActionButtonsPropsSchema.extend({
+    actions: z.array(SerializableActionSchema),
+}).omit({ className: true });
+
+export interface ActionsConfig {
+    items: Action[];
+    align?: "left" | "center" | "right";
+    confirmTimeout?: number;
+}
+
+export const SerializableActionsConfigSchema = z.object({
+    items: z.array(SerializableActionSchema).min(1),
+    align: z.enum(["left", "center", "right"]).optional(),
+    confirmTimeout: z.number().positive().optional(),
+});
+
+export type SerializableActionsConfig = z.infer<
+    typeof SerializableActionsConfigSchema
+>;
+
+export type SerializableAction = z.infer<typeof SerializableActionSchema>;

--- a/src/frontend/components/tool-ui/shared/use-action-buttons.tsx
+++ b/src/frontend/components/tool-ui/shared/use-action-buttons.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { Action } from "./schema";
+
+export type UseActionButtonsOptions = {
+    actions: Action[];
+    onAction: (actionId: string) => void | Promise<void>;
+    onBeforeAction?: (actionId: string) => boolean | Promise<boolean>;
+    confirmTimeout?: number;
+};
+
+export type UseActionButtonsResult = {
+    actions: Array<
+        Action & {
+            currentLabel: string;
+            isConfirming: boolean;
+            isExecuting: boolean;
+            isDisabled: boolean;
+            isLoading: boolean;
+        }
+    >;
+    runAction: (actionId: string) => Promise<void>;
+    confirmingActionId: string | null;
+    executingActionId: string | null;
+};
+
+export function useActionButtons(
+    options: UseActionButtonsOptions,
+): UseActionButtonsResult {
+    const {
+        actions,
+        onAction,
+        onBeforeAction,
+        confirmTimeout = 3000,
+    } = options;
+
+    const [confirmingActionId, setConfirmingActionId] = useState<string | null>(
+        null,
+    );
+    const [executingActionId, setExecutingActionId] = useState<string | null>(
+        null,
+    );
+
+    useEffect(() => {
+        if (!confirmingActionId) return;
+        const id = setTimeout(() => setConfirmingActionId(null), confirmTimeout);
+        return () => clearTimeout(id);
+    }, [confirmingActionId, confirmTimeout]);
+
+    useEffect(() => {
+        if (!confirmingActionId) return;
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Escape") {
+                setConfirmingActionId(null);
+            }
+        };
+
+        window.addEventListener("keydown", handleKeyDown);
+        return () => window.removeEventListener("keydown", handleKeyDown);
+    }, [confirmingActionId]);
+
+    const runAction = useCallback(
+        async (actionId: string) => {
+            const action = actions.find((a) => a.id === actionId);
+            if (!action) return;
+
+            const isAnyActionExecuting = executingActionId !== null;
+            if (action.disabled || action.loading || isAnyActionExecuting) {
+                return;
+            }
+
+            if (action.confirmLabel && confirmingActionId !== action.id) {
+                setConfirmingActionId(action.id);
+                return;
+            }
+
+            if (onBeforeAction) {
+                const shouldProceed = await onBeforeAction(action.id);
+                if (!shouldProceed) {
+                    setConfirmingActionId(null);
+                    return;
+                }
+            }
+
+            try {
+                setExecutingActionId(action.id);
+                await onAction(action.id);
+            } finally {
+                setExecutingActionId(null);
+                setConfirmingActionId(null);
+            }
+        },
+        [actions, confirmingActionId, executingActionId, onAction, onBeforeAction],
+    );
+
+    const resolvedActions = useMemo(
+        () =>
+            actions.map((action) => {
+                const isConfirming = confirmingActionId === action.id;
+                const isThisActionExecuting = executingActionId === action.id;
+                const isLoading = action.loading || isThisActionExecuting;
+                const isDisabled =
+                    action.disabled || (executingActionId !== null && !isThisActionExecuting);
+                const currentLabel =
+                    isConfirming && action.confirmLabel
+                        ? action.confirmLabel
+                        : action.label;
+
+                return {
+                    ...action,
+                    currentLabel,
+                    isConfirming,
+                    isExecuting: isThisActionExecuting,
+                    isDisabled,
+                    isLoading,
+                };
+            }),
+        [actions, confirmingActionId, executingActionId],
+    );
+
+    return {
+        actions: resolvedActions,
+        runAction,
+        confirmingActionId,
+        executingActionId,
+    };
+}

--- a/src/frontend/components/tool-ui/shared/use-copy-to-clipboard.ts
+++ b/src/frontend/components/tool-ui/shared/use-copy-to-clipboard.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+function fallbackCopyToClipboard(text: string): boolean {
+    try {
+        const textArea = document.createElement("textarea");
+        textArea.value = text;
+        textArea.setAttribute("readonly", "");
+        textArea.style.position = "fixed";
+        textArea.style.top = "-9999px";
+        textArea.style.left = "-9999px";
+        document.body.appendChild(textArea);
+        textArea.select();
+        const ok = document.execCommand("copy");
+        document.body.removeChild(textArea);
+        return ok;
+    } catch {
+        return false;
+    }
+}
+
+export function useCopyToClipboard(options?: {
+    resetAfterMs?: number;
+}): {
+    copiedId: string | null;
+    copy: (text: string, id?: string) => Promise<boolean>;
+} {
+    const resetAfterMs = options?.resetAfterMs ?? 2000;
+    const [copiedId, setCopiedId] = useState<string | null>(null);
+
+    const copy = useCallback(
+        async (text: string, id: string = "default") => {
+            let ok = false;
+            try {
+                if (navigator.clipboard?.writeText) {
+                    await navigator.clipboard.writeText(text);
+                    ok = true;
+                } else {
+                    ok = fallbackCopyToClipboard(text);
+                }
+            } catch {
+                ok = fallbackCopyToClipboard(text);
+            }
+
+            if (ok) {
+                setCopiedId(id);
+            }
+
+            return ok;
+        },
+        [],
+    );
+
+    useEffect(() => {
+        if (!copiedId) return;
+        const timeout = setTimeout(() => setCopiedId(null), resetAfterMs);
+        return () => clearTimeout(timeout);
+    }, [copiedId, resetAfterMs]);
+
+    return { copiedId, copy };
+}

--- a/src/frontend/components/tool-ui/shared/utils.ts
+++ b/src/frontend/components/tool-ui/shared/utils.ts
@@ -1,0 +1,29 @@
+export function formatRelativeTime(iso: string): string {
+    const seconds = Math.round((Date.now() - new Date(iso).getTime()) / 1000);
+    if (seconds < 60) return `${seconds}s`;
+    if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+    if (seconds < 86400) return `${Math.round(seconds / 3600)}h`;
+    if (seconds < 604800) return `${Math.round(seconds / 86400)}d`;
+    return `${Math.round(seconds / 604800)}w`;
+}
+
+export function formatCount(count: number): string {
+    if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+    if (count >= 1_000) return `${(count / 1_000).toFixed(1)}K`;
+    return String(count);
+}
+
+export function getDomain(url: string): string {
+    try {
+        return new URL(url).hostname.replace(/^www\./, "");
+    } catch {
+        return "";
+    }
+}
+
+export function prefersReducedMotion(): boolean {
+    return (
+        typeof window !== "undefined" &&
+        window.matchMedia?.("(prefers-reduced-motion: reduce)").matches
+    );
+}

--- a/src/frontend/components/ui/accordion.tsx
+++ b/src/frontend/components/ui/accordion.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import * as React from "react"
+import { ChevronDownIcon } from "lucide-react"
+import { Accordion as AccordionPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Accordion({
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+  return <AccordionPrimitive.Root data-slot="accordion" {...props} />
+}
+
+function AccordionItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+  return (
+    <AccordionPrimitive.Item
+      data-slot="accordion-item"
+      className={cn("border-b last:border-b-0", className)}
+      {...props}
+    />
+  )
+}
+
+function AccordionTrigger({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        data-slot="accordion-trigger"
+        className={cn(
+          "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  )
+}
+
+function AccordionContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+  return (
+    <AccordionPrimitive.Content
+      data-slot="accordion-content"
+      className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+      {...props}
+    >
+      <div className={cn("pt-0 pb-4", className)}>{children}</div>
+    </AccordionPrimitive.Content>
+  )
+}
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }

--- a/src/frontend/components/ui/badge.tsx
+++ b/src/frontend/components/ui/badge.tsx
@@ -1,0 +1,48 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-full border border-transparent px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 [a&]:hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/src/frontend/components/ui/dropdown-menu.tsx
+++ b/src/frontend/components/ui/dropdown-menu.tsx
@@ -1,0 +1,257 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  )
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/src/frontend/components/ui/table.tsx
+++ b/src/frontend/components/ui/table.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-hidden"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table, TableBody, TableCaption, TableCell, TableFooter,
+  TableHead, TableHeader, TableRow
+}
+

--- a/src/frontend/lib/column-format-rules.json
+++ b/src/frontend/lib/column-format-rules.json
@@ -1,0 +1,21 @@
+{
+    "description": "Column format inference rules for NL2SQL data tables. Edit this file to control how columns are formatted based on their names.",
+    "currencyPatterns": [
+        "price",
+        "cost",
+        "amount",
+        "revenue",
+        "due",
+        "balance",
+        "fee",
+        "charge",
+        "salary",
+        "payment",
+        "budget",
+        "spend",
+        "spent",
+        "value"
+    ],
+    "defaultCurrency": "USD",
+    "columnOverrides": {}
+}

--- a/src/frontend/lib/column-format-rules.ts
+++ b/src/frontend/lib/column-format-rules.ts
@@ -1,0 +1,140 @@
+/**
+ * Column format inference configuration.
+ *
+ * Loads rules from `column-format-rules.json` and exposes helpers
+ * that `nl2sql-tool-ui.tsx` uses to decide how columns are displayed.
+ *
+ * To change formatting behaviour, edit the JSON file — no code changes needed.
+ *
+ * ## JSON structure
+ *
+ * | Key                | Type                       | Purpose                                          |
+ * | ------------------ | -------------------------- | ------------------------------------------------ |
+ * | `currencyPatterns`  | `string[]`                | Substrings that flag a numeric column as currency |
+ * | `defaultCurrency`   | `string`                  | ISO 4217 code used for inferred currency columns  |
+ * | `columnOverrides`   | `Record<string, Override>` | Exact-match overrides keyed by column name        |
+ *
+ * ### Column overrides
+ *
+ * ```jsonc
+ * "columnOverrides": {
+ *   "AvgOrderValue": { "format": { "kind": "currency", "currency": "USD", "decimals": 2 } },
+ *   "OrderDate":     { "format": { "kind": "date", "dateFormat": "short" } },
+ *   "IsActive":      { "format": { "kind": "boolean" } }
+ * }
+ * ```
+ *
+ * Overrides take priority over pattern-based inference.
+ */
+
+import type { Column, FormatConfig } from "@/components/tool-ui/data-table";
+import rules from "./column-format-rules.json";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ColumnOverride {
+    format: FormatConfig;
+    width?: string;
+}
+
+interface ColumnFormatRules {
+    currencyPatterns: string[];
+    defaultCurrency: string;
+    columnOverrides: Record<string, ColumnOverride>;
+}
+
+// ---------------------------------------------------------------------------
+// Compiled rules (evaluated once at module load)
+// ---------------------------------------------------------------------------
+
+const config: ColumnFormatRules = {
+    currencyPatterns: rules.currencyPatterns ?? [],
+    defaultCurrency: rules.defaultCurrency ?? "USD",
+    columnOverrides: (rules.columnOverrides ?? {}) as Record<string, ColumnOverride>,
+};
+
+/** Regex built from the JSON pattern list — case-insensitive. */
+const currencyRe: RegExp = new RegExp(
+    config.currencyPatterns.join("|"),
+    "i",
+);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a compact column width for known format kinds.
+ * Returns undefined for text/unknown columns so they share remaining space.
+ */
+export function inferWidth(fmt: FormatConfig | undefined): string | undefined {
+    if (!fmt) return undefined;
+    switch (fmt.kind) {
+        case "number":
+        case "currency":
+        case "percent":
+        case "delta":
+            return "140px";
+        case "boolean":
+            return "100px";
+        case "date":
+            return "150px";
+        default:
+            return undefined;
+    }
+}
+
+/**
+ * Infer a FormatConfig from column name + sample data values.
+ *
+ * Resolution order:
+ * 1. Exact-match override from `columnOverrides`
+ * 2. Currency regex from `currencyPatterns`
+ * 3. Generic number (auto-detect decimals)
+ * 4. `undefined` (plain text)
+ */
+export function inferFormat(
+    name: string,
+    values: unknown[],
+): FormatConfig | undefined {
+    // 1. Explicit override wins
+    const override = config.columnOverrides[name];
+    if (override) return override.format;
+
+    // 2-4. Data-driven inference (only for numeric columns)
+    const nonNull = values.filter((v) => v !== null && v !== undefined);
+    if (nonNull.length === 0) return undefined;
+    if (!nonNull.every((v) => typeof v === "number")) return undefined;
+
+    const nums = nonNull as number[];
+    const hasFraction = nums.some((n) => !Number.isInteger(n));
+    const decimals = hasFraction ? 2 : 0;
+
+    if (currencyRe.test(name)) {
+        return { kind: "currency", currency: config.defaultCurrency, decimals };
+    }
+    return { kind: "number", decimals };
+}
+
+/**
+ * Build a Column definition for a single column, applying overrides and inference.
+ *
+ * Resolution: explicit override → pattern inference → plain text.
+ * Width is set from override or inferred from format kind.
+ */
+export function buildColumn(
+    name: string,
+    values: unknown[],
+    priority: "primary" | "secondary" = "secondary",
+): Column {
+    const override = config.columnOverrides[name];
+    const fmt = override?.format ?? inferFormat(name, values);
+    const width = override?.width ?? inferWidth(fmt);
+
+    const col: Column = { key: name, label: name, priority };
+    if (fmt) col.format = fmt;
+    if (width) col.width = width;
+    return col;
+}

--- a/src/frontend/next.config.ts
+++ b/src/frontend/next.config.ts
@@ -3,12 +3,12 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   // Output as static files for Azure Static Web Apps
   output: "export",
-  
+
   // Disable image optimization (not supported in static export)
   images: {
     unoptimized: true,
   },
-  
+
   // Trailing slashes help with SWA routing
   trailingSlash: true,
 };

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -40,12 +40,14 @@
     "lucide-react": "^0.563.0",
     "motion": "^12.33.0",
     "next": "16.1.6",
+    "radix-ui": "^1.4.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.4.0",
     "tw-animate-css": "^1.4.0",
+    "zod": "^3.25.76",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@ai-sdk/openai':
         specifier: ^3.0.26
-        version: 3.0.26(zod@4.3.6)
+        version: 3.0.26(zod@3.25.76)
       '@assistant-ui/react':
         specifier: ^0.12.9
         version: 0.12.9(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -46,7 +46,7 @@ importers:
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ai:
         specifier: ^6.0.75
-        version: 6.0.77(zod@4.3.6)
+        version: 6.0.77(zod@3.25.76)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -65,6 +65,9 @@ importers:
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      radix-ui:
+        specifier: ^1.4.3
+        version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -83,6 +86,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
       zustand:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@19.2.13)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
@@ -612,8 +618,50 @@ packages:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
+  '@radix-ui/number@1.1.1':
+    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
+
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-accessible-icon@1.1.7':
+    resolution: {integrity: sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-accordion@1.2.12':
+    resolution: {integrity: sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-alert-dialog@1.1.15':
+    resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
@@ -628,8 +676,47 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-aspect-ratio@1.1.7':
+    resolution: {integrity: sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-avatar@1.1.10':
+    resolution: {integrity: sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-avatar@1.1.11':
     resolution: {integrity: sha512-0Qk603AHGV28BOBO34p7IgD5m+V5Sg/YovfayABkoDDBM5d3NCx0Mp4gGrjzLGes1jV5eNOE1r3itqOR33VC6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-checkbox@1.3.3':
+    resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -674,6 +761,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-context-menu@2.2.16':
+    resolution: {integrity: sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-context@1.1.2':
@@ -764,6 +864,32 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-form@0.1.8':
+    resolution: {integrity: sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-hover-card@1.1.15':
+    resolution: {integrity: sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-id@1.1.1':
     resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
     peerDependencies:
@@ -773,8 +899,73 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-label@2.1.7':
+    resolution: {integrity: sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-menu@2.1.16':
     resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menubar@1.1.16':
+    resolution: {integrity: sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-navigation-menu@1.2.14':
+    resolution: {integrity: sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-one-time-password-field@0.1.8':
+    resolution: {integrity: sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-password-toggle-field@0.1.3':
+    resolution: {integrity: sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -864,6 +1055,32 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-progress@1.1.7':
+    resolution: {integrity: sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.3.8':
+    resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
@@ -877,8 +1094,60 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-scroll-area@1.2.10':
+    resolution: {integrity: sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-select@2.2.6':
+    resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-separator@1.1.7':
+    resolution: {integrity: sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-separator@1.1.8':
     resolution: {integrity: sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slider@1.3.6':
+    resolution: {integrity: sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -906,6 +1175,84 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-switch@1.2.6':
+    resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.13':
+    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toast@1.2.15':
+    resolution: {integrity: sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.11':
+    resolution: {integrity: sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.10':
+    resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toolbar@1.1.11':
+    resolution: {integrity: sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-tooltip@1.2.8':
@@ -968,6 +1315,15 @@ packages:
 
   '@radix-ui/react-use-layout-effect@1.1.1':
     resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.1':
+    resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2640,6 +2996,19 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  radix-ui@1.4.3:
+    resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
@@ -3140,8 +3509,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@4.1.13:
-    resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -3169,6 +3538,13 @@ packages:
 
 snapshots:
 
+  '@ai-sdk/gateway@3.0.39(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.14(zod@3.25.76)
+      '@vercel/oidc': 3.1.0
+      zod: 3.25.76
+
   '@ai-sdk/gateway@3.0.39(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -3176,11 +3552,18 @@ snapshots:
       '@vercel/oidc': 3.1.0
       zod: 4.3.6
 
-  '@ai-sdk/openai@3.0.26(zod@4.3.6)':
+  '@ai-sdk/openai@3.0.26(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.14(zod@4.3.6)
-      zod: 4.3.6
+      '@ai-sdk/provider-utils': 4.0.14(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@4.0.14(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 3.25.76
 
   '@ai-sdk/provider-utils@4.0.14(zod@4.3.6)':
     dependencies:
@@ -3648,11 +4031,75 @@ snapshots:
 
   '@opentelemetry/api@1.9.0': {}
 
+  '@radix-ui/number@1.1.1': {}
+
   '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-accessible-icon@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
+  '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
+  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.13)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
 
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
+  '@radix-ui/react-aspect-ratio@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
+  '@radix-ui/react-avatar@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.13)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -3666,6 +4113,22 @@ snapshots:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.13)(react@19.2.4)
       '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.13)(react@19.2.4)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
+  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.13)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -3705,6 +4168,20 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.13
+
+  '@radix-ui/react-context-menu@2.2.16(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
 
   '@radix-ui/react-context@1.1.2(@types/react@19.2.13)(react@19.2.4)':
     dependencies:
@@ -3791,12 +4268,52 @@ snapshots:
       '@types/react': 19.2.13
       '@types/react-dom': 19.2.3(@types/react@19.2.13)
 
+  '@radix-ui/react-form@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
+  '@radix-ui/react-hover-card@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
   '@radix-ui/react-id@1.1.1(@types/react@19.2.13)(react@19.2.4)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.13)(react@19.2.4)
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.13
+
+  '@radix-ui/react-label@2.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
 
   '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -3820,6 +4337,82 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-remove-scroll: 2.7.2(@types/react@19.2.13)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
+  '@radix-ui/react-menubar@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
+  '@radix-ui/react-navigation-menu@1.2.14(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
+  '@radix-ui/react-one-time-password-field@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
+  '@radix-ui/react-password-toggle-field@0.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.13)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.13
       '@types/react-dom': 19.2.3(@types/react@19.2.13)
@@ -3903,6 +4496,34 @@ snapshots:
       '@types/react': 19.2.13
       '@types/react-dom': 19.2.3(@types/react@19.2.13)
 
+  '@radix-ui/react-progress@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
+  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
   '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -3920,9 +4541,83 @@ snapshots:
       '@types/react': 19.2.13
       '@types/react-dom': 19.2.3(@types/react@19.2.13)
 
+  '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
+  '@radix-ui/react-select@2.2.6(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.13)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
+  '@radix-ui/react-separator@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
   '@radix-ui/react-separator@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
+  '@radix-ui/react-slider@1.3.6(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.13)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -3942,6 +4637,98 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.13
+
+  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
+  '@radix-ui/react-toast@1.2.15(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
+  '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
+  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
+  '@radix-ui/react-toolbar@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
 
   '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -3999,6 +4786,12 @@ snapshots:
       '@types/react': 19.2.13
 
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.13)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.13
+
+  '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.13)(react@19.2.4)':
     dependencies:
       react: 19.2.4
     optionalDependencies:
@@ -4312,6 +5105,14 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
+
+  ai@6.0.77(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.39(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.14(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      zod: 3.25.76
 
   ai@6.0.77(zod@4.3.6):
     dependencies:
@@ -4831,8 +5632,8 @@ snapshots:
       '@babel/parser': 7.28.5
       eslint: 10.0.0(jiti@2.6.1)
       hermes-parser: 0.25.1
-      zod: 4.1.13
-      zod-validation-error: 4.0.2(zod@4.1.13)
+      zod: 3.25.76
+      zod-validation-error: 4.0.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -5938,6 +6739,69 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-accessible-icon': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-alert-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-aspect-ratio': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-avatar': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-context-menu': 2.2.16(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-form': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-hover-card': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-menubar': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-navigation-menu': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-one-time-password-field': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-password-toggle-field': 0.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-progress': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-radio-group': 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-scroll-area': 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-select': 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slider': 1.3.6(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toast': 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toolbar': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.13)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -6598,11 +7462,11 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-validation-error@4.0.2(zod@4.1.13):
+  zod-validation-error@4.0.2(zod@3.25.76):
     dependencies:
-      zod: 4.1.13
+      zod: 3.25.76
 
-  zod@4.1.13: {}
+  zod@3.25.76: {}
 
   zod@4.3.6: {}
 

--- a/src/package.json
+++ b/src/package.json
@@ -3,14 +3,11 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"npm run dev:ui\" \"npm run dev:api\" --names ui,api --prefix-colors blue,green --kill-others",
-    "dev:ui": "cd frontend && pnpm run dev",
-    "dev:api": "../infra/scripts/run-api.sh",
+    "dev": "cd frontend && pnpm run dev",
+    "dev:ui": "cd frontend && pnpm run dev:ui",
+    "build": "cd frontend && pnpm run build",
     "setup": "npm run setup:api && npm run setup:ui",
     "setup:api": "../infra/scripts/setup-api.sh",
     "setup:ui": "cd frontend && pnpm install"
-  },
-  "devDependencies": {
-    "concurrently": "^9.1.2"
   }
 }


### PR DESCRIPTION
## Summary

Adds a reusable DataTable component for NL2SQL query results with configurable column formatting, sorting, and pagination.

## Changes

### Frontend
- **DataTable component** (`tool-ui/data-table/`): Controlled tri-state sorting, pagination (10 rows/page), responsive mobile card view, declarative `FormatConfig` system
- **Column format rules** (`lib/column-format-rules.json` + `.ts`): User-editable JSON config for currency pattern matching, column overrides, and width inference — compiled to regex at module load
- **`buildColumn()` helper**: Consolidates override lookup + format inference + width resolution into a single call
- **Simplified `nl2sql-tool-ui.tsx`**: Delegates column building to config module; `buildColumns` reduced to 3 lines
- **New shadcn components**: accordion, badge, dropdown-menu, table

### Backend
- **Decimal → float conversion** in `sql_client.py` for JSON serialization
- **Removed dead code**: `column_formats` field from `NL2SQLResponse`, unused `_CURRENCY_PATTERNS`, `_map_column_type()`, `import re`

## Testing
- Frontend build passes (`pnpm build`)
- Backend lint + typecheck passes (`uv run poe check`)