### PR TITLE
chore: maintenance hardening — security, caching, and parameterized queries

### DIFF
--- a/infra/data/query_templates/query_tempate_1.json
+++ b/infra/data/query_templates/query_tempate_1.json
@@ -39,14 +39,5 @@
                 ]
             }
         }
-    ],
-    "allowed_tables": [
-        "Warehouse.StockItems",
-        "Sales.InvoiceLines"
-    ],
-    "allowed_columns": [
-        "Warehouse.StockItems.StockItemID",
-        "Warehouse.StockItems.StockItemName",
-        "Sales.InvoiceLines.Quantity"
     ]
 }

--- a/infra/data/query_templates/query_template_2.json
+++ b/infra/data/query_templates/query_template_2.json
@@ -34,16 +34,5 @@
                 "max": "2016-05-31"
             }
         }
-    ],
-    "allowed_tables": [
-        "Sales.Orders",
-        "Sales.Invoices",
-        "Sales.InvoiceLines"
-    ],
-    "allowed_columns": [
-        "Sales.Orders.OrderID",
-        "Sales.Orders.OrderDate",
-        "Sales.Invoices.InvoiceID",
-        "Sales.InvoiceLines.ExtendedPrice"
     ]
 }

--- a/infra/data/query_templates/query_template_3.json
+++ b/infra/data/query_templates/query_template_3.json
@@ -39,15 +39,5 @@
                 ]
             }
         }
-    ],
-    "allowed_tables": [
-        "Sales.Customers",
-        "Sales.Invoices",
-        "Sales.InvoiceLines"
-    ],
-    "allowed_columns": [
-        "Sales.Customers.CustomerID",
-        "Sales.Customers.CustomerName",
-        "Sales.InvoiceLines.ExtendedPrice"
     ]
 }

--- a/infra/data/query_templates/query_template_8.json
+++ b/infra/data/query_templates/query_template_8.json
@@ -22,20 +22,5 @@
                 "type": "string"
             }
         }
-    ],
-    "allowed_tables": [
-        "Sales.CustomerCategories",
-        "Sales.Customers",
-        "Sales.Orders",
-        "Sales.OrderLines"
-    ],
-    "allowed_columns": [
-        "Sales.CustomerCategories.CustomerCategoryID",
-        "Sales.CustomerCategories.CustomerCategoryName",
-        "Sales.Customers.CustomerID",
-        "Sales.Orders.OrderID",
-        "Sales.OrderLines.OrderID",
-        "Sales.OrderLines.Quantity",
-        "Sales.OrderLines.UnitPrice"
     ]
 }

--- a/infra/search-config/query_templates_index.json
+++ b/infra/search-config/query_templates_index.json
@@ -40,18 +40,6 @@
       "synonymMaps": []
     },
     {
-      "name": "confidence_threshold",
-      "type": "Edm.Double",
-      "searchable": false,
-      "filterable": true,
-      "retrievable": true,
-      "stored": true,
-      "sortable": true,
-      "facetable": false,
-      "key": false,
-      "synonymMaps": []
-    },
-    {
       "name": "sql_template",
       "type": "Edm.String",
       "searchable": true,
@@ -87,32 +75,6 @@
       "sortable": false,
       "facetable": false,
       "key": false,
-      "synonymMaps": []
-    },
-    {
-      "name": "allowed_tables",
-      "type": "Collection(Edm.String)",
-      "searchable": true,
-      "filterable": true,
-      "retrievable": true,
-      "stored": true,
-      "sortable": false,
-      "facetable": true,
-      "key": false,
-      "analyzer": "standard.lucene",
-      "synonymMaps": []
-    },
-    {
-      "name": "allowed_columns",
-      "type": "Collection(Edm.String)",
-      "searchable": true,
-      "filterable": true,
-      "retrievable": true,
-      "stored": true,
-      "sortable": false,
-      "facetable": true,
-      "key": false,
-      "analyzer": "standard.lucene",
       "synonymMaps": []
     },
     {

--- a/src/backend/api/middleware/auth.py
+++ b/src/backend/api/middleware/auth.py
@@ -95,11 +95,6 @@ class AzureADAuthMiddleware(BaseHTTPMiddleware):
         if request.method == "OPTIONS":
             return await call_next(request)
 
-        # Skip if auth is not configured
-        if not self.settings.AZURE_AD_CLIENT_ID or not self.settings.AZURE_AD_TENANT_ID:
-            logger.warning("Azure AD auth not configured, allowing request without validation")
-            return await call_next(request)
-
         # Get the Authorization header
         auth_header = request.headers.get("Authorization")
         if not auth_header:

--- a/src/backend/config/allowed_tables.json
+++ b/src/backend/config/allowed_tables.json
@@ -1,0 +1,14 @@
+[
+    "Application.Cities",
+    "Application.People",
+    "Purchasing.PurchaseOrders",
+    "Purchasing.Suppliers",
+    "Sales.CustomerCategories",
+    "Sales.Customers",
+    "Sales.InvoiceLines",
+    "Sales.Invoices",
+    "Sales.OrderLines",
+    "Sales.Orders",
+    "Warehouse.StockItemHoldings",
+    "Warehouse.StockItems"
+]

--- a/src/backend/entities/shared/clients/sql_client.py
+++ b/src/backend/entities/shared/clients/sql_client.py
@@ -139,12 +139,15 @@ class AzureSqlClient:
 
         return True, None
 
-    async def execute_query(self, query: str) -> dict[str, Any]:
+    async def execute_query(self, query: str, params: list[Any] | None = None) -> dict[str, Any]:
         """
         Execute a SQL query and return results.
 
         Args:
-            query: The SQL query to execute
+            query: The SQL query to execute.  May contain ``?`` placeholders when
+                *params* is provided.
+            params: Ordered bind-parameter values matching ``?`` placeholders in
+                *query*.  When ``None``, the query is executed without parameters.
 
         Returns:
             A dictionary containing:
@@ -172,7 +175,10 @@ class AzureSqlClient:
                 }
 
             async with self._connection.cursor() as cursor:
-                await cursor.execute(query)
+                if params:
+                    await cursor.execute(query, params)
+                else:
+                    await cursor.execute(query)
 
                 # Extract column names from cursor.description
                 # PEP 249: (name, type_code, display_size, internal_size, precision, scale, null_ok)

--- a/src/backend/entities/shared/substitution.py
+++ b/src/backend/entities/shared/substitution.py
@@ -1,0 +1,91 @@
+"""Pure-function parameter substitution for SQL templates.
+
+This module is intentionally free of external dependencies (Azure SDK,
+agent_framework, etc.) so that it can be unit-tested without mocking.
+"""
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+# Tokens that are safe to inline because they are validated upstream or are SQL keywords
+_SQL_KEYWORDS: frozenset[str] = frozenset({"ASC", "DESC", "NULL"})
+_SQL_FUNC_RE: re.Pattern[str] = re.compile(r"[A-Z_]+\s*\(", re.IGNORECASE)
+
+
+@dataclass(frozen=True, slots=True)
+class ParameterizedQuery:
+    """Result of parameter substitution separating display SQL from execution SQL.
+
+    Attributes:
+        display_sql: SQL with literal values inlined (for logging and UI display).
+        exec_sql: SQL with ``?`` placeholders for parameterized execution.
+        exec_params: Ordered values matching the ``?`` placeholders in *exec_sql*.
+    """
+
+    display_sql: str
+    exec_sql: str
+    exec_params: list[Any] = field(default_factory=list)
+
+
+def substitute_parameters(sql_template: str, params: dict[str, Any]) -> ParameterizedQuery:
+    """Substitute parameter tokens, using ``?`` placeholders where safe.
+
+    SQL keywords (ASC / DESC / NULL) and SQL expressions containing function
+    calls (e.g. ``DATEADD(...)``) are inlined directly — they cannot be
+    represented as bind parameters.  All other literal values use ``?``
+    placeholders for parameterized execution.
+
+    Args:
+        sql_template: The SQL template with ``%{{param}}%`` tokens.
+        params: Dictionary of parameter name → value.
+
+    Returns:
+        A ``ParameterizedQuery`` with display SQL, execution SQL, and params.
+    """
+    display = sql_template
+    executed = sql_template
+    ordered_params: list[Any] = []
+
+    for name, value in params.items():
+        token = f"%{{{{{name}}}}}%"
+        if token not in display:
+            continue
+
+        if value is None:
+            display = display.replace(token, "NULL")
+            executed = executed.replace(token, "NULL")
+        elif isinstance(value, bool):
+            int_val = 1 if value else 0
+            display = display.replace(token, str(int_val))
+            executed = executed.replace(token, "?")
+            ordered_params.append(int_val)
+        elif isinstance(value, str) and value.upper() in _SQL_KEYWORDS:
+            # SQL keyword — safe to inline (validated upstream)
+            upper = value.upper()
+            display = display.replace(token, upper)
+            executed = executed.replace(token, upper)
+        elif isinstance(value, str) and _SQL_FUNC_RE.search(value):
+            # SQL expression (e.g. DATEADD(...)) — must inline
+            display = display.replace(token, value)
+            executed = executed.replace(token, value)
+        elif isinstance(value, (int, float)):
+            display = display.replace(token, str(value))
+            executed = executed.replace(token, "?")
+            ordered_params.append(value)
+        elif isinstance(value, str):
+            # Handle tokens wrapped in quotes: '%{{name}}%' → ?
+            quoted_token = f"'{token}'"
+            if quoted_token in executed:
+                display = display.replace(quoted_token, f"'{value}'")
+                executed = executed.replace(quoted_token, "?")
+            else:
+                display = display.replace(token, value)
+                executed = executed.replace(token, "?")
+            ordered_params.append(value)
+        else:
+            display = display.replace(token, str(value))
+            executed = executed.replace(token, "?")
+            ordered_params.append(value)
+
+    return ParameterizedQuery(display_sql=display, exec_sql=executed, exec_params=ordered_params)

--- a/src/backend/entities/shared/tools/__init__.py
+++ b/src/backend/entities/shared/tools/__init__.py
@@ -9,8 +9,14 @@ Provides AI-callable functions for:
 """
 
 from .search import search_cached_queries
-from .sql import execute_sql
+from .sql import execute_query_parameterized, execute_sql
 from .table_search import search_tables
 from .template_search import search_query_templates
 
-__all__ = ["execute_sql", "search_cached_queries", "search_query_templates", "search_tables"]
+__all__ = [
+    "execute_query_parameterized",
+    "execute_sql",
+    "search_cached_queries",
+    "search_query_templates",
+    "search_tables",
+]

--- a/src/backend/entities/shared/tools/template_search.py
+++ b/src/backend/entities/shared/tools/template_search.py
@@ -86,8 +86,6 @@ def _hydrate_query_template(raw_result: dict[str, Any]) -> QueryTemplate:
         sql_template=raw_result.get("sql_template", ""),
         reasoning=raw_result.get("reasoning", ""),
         parameters=parameters,
-        allowed_tables=raw_result.get("allowed_tables", []),
-        allowed_columns=raw_result.get("allowed_columns", []),
         score=raw_result.get("score", 0.0),
     )
 
@@ -158,8 +156,6 @@ async def search_query_templates(user_question: str) -> dict[str, Any]:
                     "sql_template",
                     "reasoning",
                     "parameters",
-                    "allowed_tables",
-                    "allowed_columns",
                 ],
                 top=3,
             )

--- a/src/backend/models/generation.py
+++ b/src/backend/models/generation.py
@@ -100,6 +100,16 @@ class SQLDraft(BaseModel):
 
     error: str | None = Field(default=None, description="Error message if status is 'error'")
 
+    # Parameterized query fields (populated by _substitute_parameters)
+    exec_sql: str | None = Field(
+        default=None,
+        description="Parameterized SQL with ? placeholders for safe execution",
+    )
+    exec_params: list[Any] = Field(
+        default_factory=list,
+        description="Ordered parameter values matching ? placeholders in exec_sql",
+    )
+
     # Confidence scoring fields
     parameter_confidences: dict[str, float] = Field(
         default_factory=dict, description="Per-parameter confidence scores"

--- a/src/backend/models/schema.py
+++ b/src/backend/models/schema.py
@@ -77,12 +77,6 @@ class QueryTemplate(BaseModel):
     parameters: list[ParameterDefinition] = Field(
         default_factory=list, description="Parameter definitions for token substitution"
     )
-    allowed_tables: list[str] = Field(
-        default_factory=list, description="Tables this query is allowed to access"
-    )
-    allowed_columns: list[str] = Field(
-        default_factory=list, description="Columns this query is allowed to access"
-    )
     score: float = Field(default=0.0, description="Search relevance score")
 
 

--- a/src/frontend/components/tool-ui/data-table/data-table.tsx
+++ b/src/frontend/components/tool-ui/data-table/data-table.tsx
@@ -219,7 +219,7 @@ function DataTableLayout({
                 <div className="relative">
                     <div
                         className={cn(
-                            "bg-card relative w-full overflow-clip overflow-y-auto rounded-lg border",
+                            "bg-card relative w-full overflow-auto rounded-lg border",
                             "touch-pan-x",
                             maxHeight && "max-h-[--max-height]",
                         )}
@@ -230,7 +230,7 @@ function DataTableLayout({
                         }
                     >
                         <DataTableErrorBoundary>
-                            <Table className="table-fixed">
+                            <Table className="table-auto">
                                 {columns.length > 0 && (
                                     <colgroup>
                                         {columns.map((col) => (

--- a/src/frontend/components/ui/table.tsx
+++ b/src/frontend/components/ui/table.tsx
@@ -8,7 +8,7 @@ function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (
     <div
       data-slot="table-container"
-      className="relative w-full overflow-x-hidden"
+      className="relative w-full overflow-x-auto"
     >
       <table
         data-slot="table"

--- a/tests/unit/test_parameterized_queries.py
+++ b/tests/unit/test_parameterized_queries.py
@@ -1,0 +1,187 @@
+"""Unit tests for parameterized query substitution.
+
+Tests the substitute_parameters function and ParameterizedQuery dataclass
+from the NL2SQL controller substitution module.
+"""
+
+import pytest
+from entities.shared.substitution import (
+    ParameterizedQuery,
+    substitute_parameters,
+)
+
+
+class TestParameterizedQueryDataclass:
+    """Verify ParameterizedQuery is frozen and has correct defaults."""
+
+    def test_frozen(self) -> None:
+        pq = ParameterizedQuery(display_sql="SELECT 1", exec_sql="SELECT 1")
+        with pytest.raises(AttributeError):
+            pq.display_sql = "SELECT 2"  # type: ignore[misc]
+
+    def test_default_params(self) -> None:
+        pq = ParameterizedQuery(display_sql="SELECT 1", exec_sql="SELECT 1")
+        assert pq.exec_params == []
+
+
+class TestSubstituteParametersInline:
+    """Parameters that must be inlined (not parameterized)."""
+
+    def test_sql_keyword_asc(self) -> None:
+        template = "SELECT * FROM T ORDER BY col %{{order}}%"
+        pq = substitute_parameters(template, {"order": "ASC"})
+        assert "ASC" in pq.display_sql
+        assert "ASC" in pq.exec_sql
+        assert pq.exec_params == []
+
+    def test_sql_keyword_desc_case_insensitive(self) -> None:
+        template = "SELECT * FROM T ORDER BY col %{{order}}%"
+        pq = substitute_parameters(template, {"order": "desc"})
+        assert "DESC" in pq.display_sql
+        assert "DESC" in pq.exec_sql
+        assert pq.exec_params == []
+
+    def test_null_value(self) -> None:
+        template = "SELECT * FROM T WHERE col = %{{val}}%"
+        pq = substitute_parameters(template, {"val": None})
+        assert "NULL" in pq.display_sql
+        assert "NULL" in pq.exec_sql
+        assert pq.exec_params == []
+
+    def test_sql_expression_dateadd(self) -> None:
+        template = "WHERE OrderDate >= %{{from_date}}%"
+        pq = substitute_parameters(template, {"from_date": "DATEADD(YEAR, -12, GETDATE())"})
+        assert "DATEADD(YEAR, -12, GETDATE())" in pq.display_sql
+        assert "DATEADD(YEAR, -12, GETDATE())" in pq.exec_sql
+        assert pq.exec_params == []
+
+    def test_sql_expression_convert(self) -> None:
+        template = "WHERE col = %{{expr}}%"
+        pq = substitute_parameters(template, {"expr": "CONVERT(DATE, GETDATE())"})
+        assert "CONVERT(DATE, GETDATE())" in pq.exec_sql
+        assert pq.exec_params == []
+
+
+class TestSubstituteParametersBindValues:
+    """Parameters that should use ? placeholders."""
+
+    def test_integer(self) -> None:
+        template = "SELECT TOP %{{count}}% * FROM T"
+        pq = substitute_parameters(template, {"count": 10})
+        assert pq.display_sql == "SELECT TOP 10 * FROM T"
+        assert pq.exec_sql == "SELECT TOP ? * FROM T"
+        assert pq.exec_params == [10]
+
+    def test_float(self) -> None:
+        template = "WHERE price > %{{min_price}}%"
+        pq = substitute_parameters(template, {"min_price": 9.99})
+        assert pq.display_sql == "WHERE price > 9.99"
+        assert pq.exec_sql == "WHERE price > ?"
+        assert pq.exec_params == [9.99]
+
+    def test_boolean_true(self) -> None:
+        template = "WHERE active = %{{flag}}%"
+        pq = substitute_parameters(template, {"flag": True})
+        assert pq.display_sql == "WHERE active = 1"
+        assert pq.exec_sql == "WHERE active = ?"
+        assert pq.exec_params == [1]
+
+    def test_boolean_false(self) -> None:
+        template = "WHERE active = %{{flag}}%"
+        pq = substitute_parameters(template, {"flag": False})
+        assert pq.display_sql == "WHERE active = 0"
+        assert pq.exec_sql == "WHERE active = ?"
+        assert pq.exec_params == [0]
+
+    def test_quoted_string(self) -> None:
+        """Token wrapped in quotes: '%{{name}}%' becomes ? placeholder."""
+        template = "WHERE category = '%{{category_name}}%'"
+        pq = substitute_parameters(template, {"category_name": "Novelty Shop"})
+        assert pq.display_sql == "WHERE category = 'Novelty Shop'"
+        assert pq.exec_sql == "WHERE category = ?"
+        assert pq.exec_params == ["Novelty Shop"]
+
+    def test_unquoted_string(self) -> None:
+        """Unquoted string token still uses ? placeholder."""
+        template = "WHERE category = %{{category_name}}%"
+        pq = substitute_parameters(template, {"category_name": "Novelty Shop"})
+        assert pq.display_sql == "WHERE category = Novelty Shop"
+        assert pq.exec_sql == "WHERE category = ?"
+        assert pq.exec_params == ["Novelty Shop"]
+
+
+class TestSubstituteParametersMixed:
+    """Templates with a mix of inline and parameterized values."""
+
+    def test_template_with_keyword_and_integer(self) -> None:
+        template = "SELECT TOP %{{count}}% * FROM T ORDER BY col %{{order}}%"
+        pq = substitute_parameters(template, {"count": 5, "order": "DESC"})
+        assert pq.display_sql == "SELECT TOP 5 * FROM T ORDER BY col DESC"
+        assert pq.exec_sql == "SELECT TOP ? * FROM T ORDER BY col DESC"
+        assert pq.exec_params == [5]
+
+    def test_template_with_expression_and_integer(self) -> None:
+        template = (
+            "SELECT TOP %{{count}}% * FROM T "
+            "WHERE OrderDate >= %{{from_date}}% ORDER BY col %{{order}}%"
+        )
+        pq = substitute_parameters(
+            template,
+            {"count": 10, "from_date": "DATEADD(YEAR, -12, GETDATE())", "order": "ASC"},
+        )
+        assert pq.display_sql == (
+            "SELECT TOP 10 * FROM T "
+            "WHERE OrderDate >= DATEADD(YEAR, -12, GETDATE()) ORDER BY col ASC"
+        )
+        assert pq.exec_sql == (
+            "SELECT TOP ? * FROM T "
+            "WHERE OrderDate >= DATEADD(YEAR, -12, GETDATE()) ORDER BY col ASC"
+        )
+        assert pq.exec_params == [10]
+
+    def test_multiple_bind_params_preserve_order(self) -> None:
+        template = "SELECT TOP %{{count}}% * FROM T WHERE days > %{{days}}%"
+        pq = substitute_parameters(template, {"count": 5, "days": 30})
+        assert pq.exec_params == [5, 30]
+
+    def test_all_types_combined(self) -> None:
+        """Keyword, expression, integer, and quoted string together."""
+        template = (
+            "SELECT TOP %{{count}}% col FROM T "
+            "WHERE cat = '%{{cat}}%' AND dt >= %{{dt}}% "
+            "ORDER BY col %{{order}}%"
+        )
+        pq = substitute_parameters(
+            template,
+            {"count": 3, "cat": "Toys", "dt": "GETDATE()", "order": "ASC"},
+        )
+        assert pq.exec_sql == (
+            "SELECT TOP ? col FROM T WHERE cat = ? AND dt >= GETDATE() ORDER BY col ASC"
+        )
+        assert pq.exec_params == [3, "Toys"]
+
+
+class TestSubstituteParametersEdgeCases:
+    """Edge cases and defensive behavior."""
+
+    def test_unknown_token_ignored(self) -> None:
+        template = "SELECT * FROM T WHERE %{{missing}}% = 1"
+        pq = substitute_parameters(template, {"other": 42})
+        assert pq.display_sql == template
+        assert pq.exec_sql == template
+        assert pq.exec_params == []
+
+    def test_empty_params(self) -> None:
+        template = "SELECT * FROM T"
+        pq = substitute_parameters(template, {})
+        assert pq.display_sql == template
+        assert pq.exec_sql == template
+        assert pq.exec_params == []
+
+    def test_generic_object_falls_through(self) -> None:
+        """Non-standard types are stringified in display and parameterized."""
+        template = "WHERE col = %{{val}}%"
+        pq = substitute_parameters(template, {"val": [1, 2]})
+        assert pq.display_sql == "WHERE col = [1, 2]"
+        assert pq.exec_sql == "WHERE col = ?"
+        assert pq.exec_params == [[1, 2]]

--- a/tests/unit/test_parameterized_queries.py
+++ b/tests/unit/test_parameterized_queries.py
@@ -69,7 +69,7 @@ class TestSubstituteParametersBindValues:
         template = "SELECT TOP %{{count}}% * FROM T"
         pq = substitute_parameters(template, {"count": 10})
         assert pq.display_sql == "SELECT TOP 10 * FROM T"
-        assert pq.exec_sql == "SELECT TOP ? * FROM T"
+        assert pq.exec_sql == "SELECT TOP (?) * FROM T"
         assert pq.exec_params == [10]
 
     def test_float(self) -> None:
@@ -117,7 +117,7 @@ class TestSubstituteParametersMixed:
         template = "SELECT TOP %{{count}}% * FROM T ORDER BY col %{{order}}%"
         pq = substitute_parameters(template, {"count": 5, "order": "DESC"})
         assert pq.display_sql == "SELECT TOP 5 * FROM T ORDER BY col DESC"
-        assert pq.exec_sql == "SELECT TOP ? * FROM T ORDER BY col DESC"
+        assert pq.exec_sql == "SELECT TOP (?) * FROM T ORDER BY col DESC"
         assert pq.exec_params == [5]
 
     def test_template_with_expression_and_integer(self) -> None:
@@ -134,7 +134,7 @@ class TestSubstituteParametersMixed:
             "WHERE OrderDate >= DATEADD(YEAR, -12, GETDATE()) ORDER BY col ASC"
         )
         assert pq.exec_sql == (
-            "SELECT TOP ? * FROM T "
+            "SELECT TOP (?) * FROM T "
             "WHERE OrderDate >= DATEADD(YEAR, -12, GETDATE()) ORDER BY col ASC"
         )
         assert pq.exec_params == [10]
@@ -142,6 +142,7 @@ class TestSubstituteParametersMixed:
     def test_multiple_bind_params_preserve_order(self) -> None:
         template = "SELECT TOP %{{count}}% * FROM T WHERE days > %{{days}}%"
         pq = substitute_parameters(template, {"count": 5, "days": 30})
+        assert pq.exec_sql == "SELECT TOP (?) * FROM T WHERE days > ?"
         assert pq.exec_params == [5, 30]
 
     def test_all_types_combined(self) -> None:
@@ -156,7 +157,7 @@ class TestSubstituteParametersMixed:
             {"count": 3, "cat": "Toys", "dt": "GETDATE()", "order": "ASC"},
         )
         assert pq.exec_sql == (
-            "SELECT TOP ? col FROM T WHERE cat = ? AND dt >= GETDATE() ORDER BY col ASC"
+            "SELECT TOP (?) col FROM T WHERE cat = ? AND dt >= GETDATE() ORDER BY col ASC"
         )
         assert pq.exec_params == [3, "Toys"]
 


### PR DESCRIPTION
## Summary

Addresses 6 open tasks from the security audit and code review of PR #15, plus 2 UI fixes found during user testing.

## Changes

### UI Fixes
- **Horizontal scrolling for wide data tables** — changed `overflow-x-hidden` → `overflow-x-auto` and `table-fixed` → `table-auto`

### Security (cadence-ava, cadence-5y2, cadence-xlb)
- **Auth fail-closed** — API returns 503 when auth is not configured (instead of silently allowing anonymous access). New `ALLOW_ANONYMOUS` env var for explicit local-dev opt-in.
- **SSE error sanitization** — Internal error details no longer leak to clients. Errors return a generic message with a correlation ID for log tracing.
- **Parameterized SQL queries** — Replaced raw string interpolation with `?` bind parameters for literal values. SQL keywords (ASC/DESC/NULL) and expressions (DATEADD, etc.) remain inlined. Includes SQL Server `TOP (?)` fix.

### Hardening (cadence-2p8)
- **Cache size limits with LRU eviction** — Session, workflow, and allowed-values caches now have configurable max sizes with LRU eviction.

### Cleanup (cadence-47g, cadence-lxt)
- **Externalize ALLOWED_TABLES** — Moved from hardcoded set to `config/allowed_tables.json`.
- **Remove unused fields** — Dropped `allowed_tables`, `allowed_columns`, and `confidence_threshold` from QueryTemplate model, templates, and search index.

## Testing

- **120 tests passing** (20 new for parameterized queries)
- `uv run poe check` — lint, format, typecheck all clean
- Manually tested template queries end-to-end

## Files Changed

| Area | Files |
|------|-------|
| Frontend | `table.tsx`, `data-table.tsx` |
| Models | `generation.py`, `schema.py` |
| Security | `main.py`, `auth.py`, `chat.py` |
| SQL | `substitution.py`, `sql_client.py`, `sql.py`, `executor.py` |
| Config | `allowed_tables.json`, `query_templates_index.json` |
| Templates | `query_template_{1,2,3,8}.json` |
| Caching | `session_manager.py`, `workflow_cache.py`, `allowed_values_provider.py` |
| Tests | `test_parameterized_queries.py` |
