### PR TITLE
chore(ci): add timeout guard to ACR build step

### DIFF
--- a/.github/workflows/cd-api.yml
+++ b/.github/workflows/cd-api.yml
@@ -35,6 +35,7 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Build and push image using ACR Tasks
+        timeout-minutes: 20
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
add timeout for continous deployment jobs
