### PR TITLE
fix(evaluations): use actions vars for eval env

### DIFF
--- a/.github/workflows/eval-nightly.yml
+++ b/.github/workflows/eval-nightly.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Harvest Foundry traces and merge with gold dataset
         env:
           PYTHONPATH: src/backend
-          AZURE_AI_PROJECT_ENDPOINT: ${{ secrets.AZURE_AI_PROJECT_ENDPOINT }}
-          AZURE_AI_MODEL_DEPLOYMENT_NAME: ${{ secrets.AZURE_AI_MODEL_DEPLOYMENT_NAME }}
+          AZURE_AI_PROJECT_ENDPOINT: ${{ vars.AZURE_AI_PROJECT_ENDPOINT }}
+          AZURE_AI_MODEL_DEPLOYMENT_NAME: ${{ vars.AZURE_AI_MODEL_DEPLOYMENT_NAME }}
         run: |
           uv run python -m evaluations harvest \
             --output .foundry/datasets \
@@ -56,8 +56,8 @@ jobs:
         env:
           PYTHONPATH: src/backend
           # Evaluation runner and trace harvesting
-          AZURE_AI_PROJECT_ENDPOINT: ${{ secrets.AZURE_AI_PROJECT_ENDPOINT }}
-          AZURE_AI_MODEL_DEPLOYMENT_NAME: ${{ secrets.AZURE_AI_MODEL_DEPLOYMENT_NAME }}
+          AZURE_AI_PROJECT_ENDPOINT: ${{ vars.AZURE_AI_PROJECT_ENDPOINT }}
+          AZURE_AI_MODEL_DEPLOYMENT_NAME: ${{ vars.AZURE_AI_MODEL_DEPLOYMENT_NAME }}
           # For evaluating SQL safety and executing queries
           AZURE_SEARCH_ENDPOINT: ${{ secrets.AZURE_SEARCH_ENDPOINT }}
           AZURE_SEARCH_INDEX_TABLES: ${{ secrets.AZURE_SEARCH_INDEX_TABLES }}

--- a/.github/workflows/eval-pr-gate.yml
+++ b/.github/workflows/eval-pr-gate.yml
@@ -33,8 +33,8 @@ jobs:
         env:
           PYTHONPATH: src/backend
           # Evaluation runner
-          AZURE_AI_PROJECT_ENDPOINT: ${{ secrets.AZURE_AI_PROJECT_ENDPOINT }}
-          AZURE_AI_MODEL_DEPLOYMENT_NAME: ${{ secrets.AZURE_AI_MODEL_DEPLOYMENT_NAME }}
+          AZURE_AI_PROJECT_ENDPOINT: ${{ vars.AZURE_AI_PROJECT_ENDPOINT }}
+          AZURE_AI_MODEL_DEPLOYMENT_NAME: ${{ vars.AZURE_AI_MODEL_DEPLOYMENT_NAME }}
           # For evaluating SQL safety and executing queries
           AZURE_SEARCH_ENDPOINT: ${{ secrets.AZURE_SEARCH_ENDPOINT }}
           AZURE_SEARCH_INDEX_TABLES: ${{ secrets.AZURE_SEARCH_INDEX_TABLES }}


### PR DESCRIPTION
## Summary\n- update eval workflows to use GitHub Actions repository variables for Foundry endpoint and model deployment name\n- remove secret fallback for non-secret config values\n\n## Why\nThe eval run failed because workflow env resolved from `secrets.*` while the values are configured as repository variables.\n\n## Validation\n- verified workflow env mappings now use `vars.AZURE_AI_PROJECT_ENDPOINT` and `vars.AZURE_AI_MODEL_DEPLOYMENT_NAME` in nightly and PR gate workflows