### PR TITLE
fix(ci): add azure/login to eval workflows for managed identity auth

### DIFF
--- a/.github/workflows/eval-nightly.yml
+++ b/.github/workflows/eval-nightly.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
   issues: write
 
 jobs:
@@ -16,6 +17,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Login to Azure
+        uses: azure/login@v2.3.0
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/.github/workflows/eval-update-dataset.yml
+++ b/.github/workflows/eval-update-dataset.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   eval-update-dataset:
@@ -17,6 +18,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Login to Azure
+        uses: azure/login@v2.3.0
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4


### PR DESCRIPTION
The self-hosted runner's App Service managed identity returns HTTP 400 when DefaultAzureCredential requests 'https://ai.azure.com/.default'. Add azure/login@v2.3.0 + id-token: write to eval-update-dataset.yml and eval-nightly.yml so WorkloadIdentityCredential is used instead, matching the auth pattern already proven in cd-api.yml.