### PR TITLE
fix(ci): remove unsupported evaluators from nightly workflow

### DIFF
--- a/.github/workflows/eval-nightly.yml
+++ b/.github/workflows/eval-nightly.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           uv run python -m evaluations run \
             --dataset src/backend/evaluations/datasets/cadence-eval-gold-v1.jsonl \
-            --evaluators intent_resolution,task_adherence,relevance,tool_call_accuracy,indirect_attack,sql_safety,param_extraction_correctness,answer_adequacy,clarification_quality \
+            --evaluators intent_resolution,task_adherence,relevance,tool_call_accuracy,indirect_attack \
             --trigger nightly \
             --cloud
 


### PR DESCRIPTION
Foundry cloud evaluation API only supports 5 built-in evaluators:
- intent_resolution
- task_adherence
- relevance
- tool_call_accuracy
- indirect_attack

The workflow was requesting 4 additional unsupported evaluators:
- sql_safety
- param_extraction_correctness
- answer_adequacy
- clarification_quality

These were silently skipped, causing evaluation runs to hang/get stuck. This commit removes them from the nightly workflow to match what Foundry cloud actually supports.

Note: If these evaluators are needed, they should be run locally via the --local flag with custom evaluator implementations.