### PR TITLE
chore(eval-nightly): codify UAMI Foundry RBAC and parameterize client id

### DIFF
--- a/.github/workflows/eval-nightly.yml
+++ b/.github/workflows/eval-nightly.yml
@@ -27,8 +27,8 @@ jobs:
         uses: azure/login@v2.3.0
         with:
           auth-type: IDENTITY
-          # cadence-gh-runner-id user-assigned managed identity
-          client-id: 3dba5eb2-7685-4a8f-b3ee-1a89305f36f6
+          # cadence-gh-runner-id user-assigned managed identity (client ID synced from Terraform output)
+          client-id: ${{ vars.EVALUATIONS_RUNNER_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 

--- a/infra/scripts/update-github-vars-from-terraform.sh
+++ b/infra/scripts/update-github-vars-from-terraform.sh
@@ -227,6 +227,7 @@ fi
 set_repo_var "AZURE_FOUNDRY_DATASET_VERSION" "$foundry_dataset_version"
 map_and_set "AZURE_AI_PROJECT_ENDPOINT" "ai_project_endpoint"
 map_and_set "AZURE_GH_RUNNER_IDENTITY_NAME" "github_runner_identity_name"
+map_and_set "EVALUATIONS_RUNNER_CLIENT_ID" "github_runner_identity_client_id"
 map_and_set "AZURE_SUBSCRIPTION_ID" "azure_subscription_id"
 map_and_set "AZURE_TENANT_ID" "azure_tenant_id"
 

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -112,6 +112,11 @@ output "github_runner_identity_principal_id" {
   value       = azurerm_user_assigned_identity.github_runner.principal_id
 }
 
+output "github_runner_identity_client_id" {
+  description = "Private GitHub runner managed identity client ID (used by azure/login auth-type=IDENTITY)"
+  value       = azurerm_user_assigned_identity.github_runner.client_id
+}
+
 output "container_registry_login_server" {
   description = "Container Registry login server"
   value       = module.container_registry.resource.login_server

--- a/infra/terraform/security.tf
+++ b/infra/terraform/security.tf
@@ -127,3 +127,34 @@ resource "azurerm_role_assignment" "github_runner_openai_user" {
 
   depends_on = [time_sleep.github_runner_identity_propagation]
 }
+
+resource "azurerm_role_assignment" "github_runner_ai_developer_rg" {
+  # REQUIRED for the runner UAMI to submit Foundry cloud evaluation runs and
+  # have them complete. The Foundry evaluation engine uploads results via the
+  # AzureML data-plane endpoint `evaluations/runs:updateUpload`, which is gated
+  # by `Microsoft.MachineLearningServices/workspaces/evaluations/*` actions.
+  # Those actions are part of the "Azure AI Developer" role; "Azure AI User"
+  # alone is NOT sufficient and runs fail with PermissionDenied.
+  #
+  # Scope is the resource group so the grant covers the Foundry account, its
+  # projects, and any associated AzureML/storage data-plane resources used by
+  # the eval engine.
+  scope                = azurerm_resource_group.private_rg.id
+  role_definition_name = "Azure AI Developer"
+  principal_id         = azurerm_user_assigned_identity.github_runner.principal_id
+
+  depends_on = [time_sleep.github_runner_identity_propagation]
+}
+
+resource "azurerm_role_assignment" "github_runner_ai_foundry_user_project" {
+  # Project-scope Azure AI User mirrors the typical Foundry RBAC pattern for
+  # principals that interact with a specific project (datasets, evals,
+  # threads). Account-scope grant above provides cross-project capability;
+  # this project-scope grant ensures the SDK's project-scoped resolver finds
+  # the principal when project-only checks are performed.
+  scope                = module.ai_foundry.ai_foundry_project_id["cadence"]
+  role_definition_name = "Azure AI User"
+  principal_id         = azurerm_user_assigned_identity.github_runner.principal_id
+
+  depends_on = [time_sleep.github_runner_identity_propagation]
+}


### PR DESCRIPTION
- Add Azure AI Developer role at RG scope and Azure AI User at project scope for the GitHub runner UAMI in Terraform (security.tf). The Foundry cloud eval data-plane (evaluations/runs:updateUpload) requires Azure AI Developer; Azure AI User alone yields PermissionDenied.
- Expose runner UAMI client id as a Terraform output and sync it to a new GitHub Actions repository variable EVALUATIONS_RUNNER_CLIENT_ID via update-github-vars-from-terraform.sh.
- Replace the hardcoded UAMI client id in eval-nightly.yml with the new variable.